### PR TITLE
feat: support cookie token auth

### DIFF
--- a/internal/adapters/authenticators/identity/custom_identity/custom.go
+++ b/internal/adapters/authenticators/identity/custom_identity/custom.go
@@ -53,6 +53,13 @@ func (c *CustomIdentityFactory) Identify(ctx context.Context, token string) (str
 	return externalUserID, nil
 }
 
+func (c *CustomIdentityFactory) GetCookieFieldName() string {
+	if c.config.CookieFieldName == nil {
+		return ""
+	}
+	return *c.config.CookieFieldName
+}
+
 func (c *CustomIdentityFactory) validatePEM(token string) (string, error) {
 
 	keyFunc, err := getKeyFuncFromPEM([]byte(c.config.PEM), c.config.KeyType)

--- a/internal/adapters/authenticators/identity/openfort_identity/openfort.go
+++ b/internal/adapters/authenticators/identity/openfort_identity/openfort.go
@@ -57,6 +57,10 @@ func (o *OpenfortIdentityFactory) Identify(ctx context.Context, token string) (s
 	return o.accessToken(ctx, token)
 }
 
+func (a *OpenfortIdentityFactory) GetCookieFieldName() string {
+	return ""
+}
+
 func (o *OpenfortIdentityFactory) accessToken(_ context.Context, token string) (string, error) {
 	return jwk.Validate(token, fmt.Sprintf("%s/iam/v1/%s/jwks.json", o.baseURL, o.publishableKey))
 }

--- a/internal/adapters/handlers/rest/projecthdl/handler.go
+++ b/internal/adapters/handlers/rest/projecthdl/handler.go
@@ -271,6 +271,10 @@ func (h *Handler) UpdateProvider(w http.ResponseWriter, r *http.Request) {
 		opts = append(opts, projectapp.WithCustomPEM(req.PEM, h.parser.mapKeyTypeToDomain[req.KeyType]))
 	}
 
+	if req.CookieFieldName != nil {
+		opts = append(opts, projectapp.WithCustomCookieFieldName(*req.CookieFieldName))
+	}
+
 	err = h.app.UpdateProvider(ctx, providerID, opts...)
 	if err != nil {
 		api.RespondWithError(w, fromApplicationError(err))

--- a/internal/adapters/handlers/rest/projecthdl/parser.go
+++ b/internal/adapters/handlers/rest/projecthdl/parser.go
@@ -58,6 +58,10 @@ func (p *parser) fromAddProvidersRequest(req *AddProvidersRequest) []projectapp.
 		opts = append(opts, projectapp.WithCustomPEM(req.Providers.Custom.PEM, p.mapKeyTypeToDomain[req.Providers.Custom.KeyType]))
 	}
 
+	if req.Providers.Custom != nil && req.Providers.Custom.CookieFieldName != nil {
+		opts = append(opts, projectapp.WithCustomCookieFieldName(*req.Providers.Custom.CookieFieldName))
+	}
+
 	return opts
 }
 
@@ -103,6 +107,7 @@ func (p *parser) toGetProviderResponse(prov *provider.Provider) *GetProviderResp
 	case provider.TypeCustom:
 		resp.JWK = prov.Config.(*provider.CustomConfig).JWK
 		resp.PEM = prov.Config.(*provider.CustomConfig).PEM
+		resp.CookieFieldName = prov.Config.(*provider.CustomConfig).CookieFieldName
 		resp.KeyType = p.mapKeyTypeToResponse[prov.Config.(*provider.CustomConfig).KeyType]
 	case provider.TypeUnknown:
 	}

--- a/internal/adapters/handlers/rest/projecthdl/types.go
+++ b/internal/adapters/handlers/rest/projecthdl/types.go
@@ -33,10 +33,11 @@ type OpenfortProvider struct {
 }
 
 type CustomProvider struct {
-	ProviderID string  `json:"provider_id,omitempty"`
-	JWK        string  `json:"jwk,omitempty"`
-	PEM        string  `json:"pem,omitempty"`
-	KeyType    KeyType `json:"key_type,omitempty"`
+	ProviderID      string  `json:"provider_id,omitempty"`
+	JWK             string  `json:"jwk,omitempty"`
+	PEM             string  `json:"pem,omitempty"`
+	CookieFieldName *string `json:"cookie_field_name,omitempty"`
+	KeyType         KeyType `json:"key_type,omitempty"`
 }
 
 type KeyType string
@@ -61,19 +62,21 @@ type GetProvidersResponse struct {
 }
 
 type GetProviderResponse struct {
-	ProviderID     string  `json:"provider_id"`
-	Type           string  `json:"type"`
-	PublishableKey string  `json:"publishable_key,omitempty"`
-	JWK            string  `json:"jwk,omitempty"`
-	PEM            string  `json:"pem,omitempty"`
-	KeyType        KeyType `json:"key_type,omitempty"`
+	ProviderID      string  `json:"provider_id"`
+	Type            string  `json:"type"`
+	PublishableKey  string  `json:"publishable_key,omitempty"`
+	JWK             string  `json:"jwk,omitempty"`
+	PEM             string  `json:"pem,omitempty"`
+	CookieFieldName *string `json:"cookie_field_name,omitempty"`
+	KeyType         KeyType `json:"key_type,omitempty"`
 }
 
 type UpdateProviderRequest struct {
-	PublishableKey string  `json:"publishable_key,omitempty"`
-	JWK            string  `json:"jwk,omitempty"`
-	PEM            string  `json:"pem,omitempty"`
-	KeyType        KeyType `json:"key_type,omitempty"`
+	PublishableKey  string  `json:"publishable_key,omitempty"`
+	JWK             string  `json:"jwk,omitempty"`
+	PEM             string  `json:"pem,omitempty"`
+	CookieFieldName *string `json:"cookie_field_name,omitempty"`
+	KeyType         KeyType `json:"key_type,omitempty"`
 }
 
 type EncryptBodyRequest struct {

--- a/internal/adapters/repositories/sql/migrations/20250729175143_cookie_field.sql
+++ b/internal/adapters/repositories/sql/migrations/20250729175143_cookie_field.sql
@@ -1,0 +1,8 @@
+-- +goose Up
+ALTER TABLE shld_custom_providers
+ADD COLUMN cookie_field_name VARCHAR(64) DEFAULT NULL;
+
+
+-- +goose Down
+ALTER TABLE shld_custom_providers
+DROP COLUMN IF EXISTS cookie_field_name;

--- a/internal/adapters/repositories/sql/providerrepo/parser.go
+++ b/internal/adapters/repositories/sql/providerrepo/parser.go
@@ -83,20 +83,31 @@ func (p *parser) toDatabaseCustomProvider(prov *provider.CustomConfig) *Provider
 		pem = &prov.PEM
 	}
 
+	var cookieFieldName *string
+	if prov.CookieFieldName != nil {
+		cookieFieldName = prov.CookieFieldName
+	}
+
 	var keyType *KeyType
 	if keyTypeStr := p.mapKeyTypeToDatabase[prov.KeyType]; keyTypeStr != "" {
 		keyType = &keyTypeStr
 	}
 	return &ProviderCustom{
-		ProviderID: prov.ProviderID,
-		JWKUrl:     jwkURL,
-		PEM:        pem,
-		KeyType:    keyType,
+		ProviderID:      prov.ProviderID,
+		JWKUrl:          jwkURL,
+		PEM:             pem,
+		KeyType:         keyType,
+		CookieFieldName: cookieFieldName,
 	}
 }
 
 func (p *parser) toUpdateCustomProviderMap(prov *provider.CustomConfig) map[string]interface{} {
 	updates := make(map[string]interface{})
+
+	if prov.CookieFieldName != nil {
+		updates["cookie_field_name"] = *prov.CookieFieldName
+	}
+
 	if prov.JWK != "" {
 		updates["jwk_url"] = prov.JWK
 		updates["pem_cert"] = nil
@@ -122,14 +133,20 @@ func (p *parser) toDomainCustomProvider(prov *ProviderCustom) *provider.CustomCo
 		pem = *prov.PEM
 	}
 
+	cookieFieldName := ""
+	if prov.CookieFieldName != nil {
+		cookieFieldName = *prov.CookieFieldName
+	}
+
 	keyType := provider.KeyTypeUnknown
 	if prov.KeyType != nil {
 		keyType = p.mapKeyTypeToDomain[*prov.KeyType]
 	}
 	return &provider.CustomConfig{
-		ProviderID: prov.ProviderID,
-		JWK:        jwk,
-		PEM:        pem,
-		KeyType:    keyType,
+		ProviderID:      prov.ProviderID,
+		JWK:             jwk,
+		PEM:             pem,
+		KeyType:         keyType,
+		CookieFieldName: &cookieFieldName,
 	}
 }

--- a/internal/adapters/repositories/sql/providerrepo/types.go
+++ b/internal/adapters/repositories/sql/providerrepo/types.go
@@ -39,10 +39,11 @@ func (ProviderOpenfort) TableName() string {
 }
 
 type ProviderCustom struct {
-	ProviderID string   `gorm:"column:provider_id;primary_key"`
-	JWKUrl     *string  `gorm:"column:jwk_url"`
-	PEM        *string  `gorm:"column:pem_cert"`
-	KeyType    *KeyType `gorm:"column:key_type"`
+	ProviderID      string   `gorm:"column:provider_id;primary_key"`
+	JWKUrl          *string  `gorm:"column:jwk_url"`
+	PEM             *string  `gorm:"column:pem_cert"`
+	CookieFieldName *string  `gorm:"column:cookie_field_name"`
+	KeyType         *KeyType `gorm:"column:key_type"`
 }
 
 func (ProviderCustom) TableName() string {

--- a/internal/applications/projectapp/options.go
+++ b/internal/applications/projectapp/options.go
@@ -17,6 +17,12 @@ func WithCustomPEM(pem string, keyType provider.KeyType) ProviderOption {
 	}
 }
 
+func WithCustomCookieFieldName(cookieFieldName string) ProviderOption {
+	return func(c *providerConfig) {
+		c.cookieFieldName = &cookieFieldName
+	}
+}
+
 func WithOpenfort(openfortProjectID string) ProviderOption {
 	return func(c *providerConfig) {
 		c.openfortPublishableKey = &openfortProjectID
@@ -26,6 +32,7 @@ func WithOpenfort(openfortProjectID string) ProviderOption {
 type providerConfig struct {
 	jwkURL                 *string
 	pem                    *string
+	cookieFieldName        *string
 	keyType                provider.KeyType
 	openfortPublishableKey *string
 }

--- a/internal/core/domain/provider/customcfg.go
+++ b/internal/core/domain/provider/customcfg.go
@@ -1,10 +1,11 @@
 package provider
 
 type CustomConfig struct {
-	ProviderID string
-	JWK        string
-	PEM        string
-	KeyType    KeyType
+	ProviderID      string
+	JWK             string
+	PEM             string
+	CookieFieldName *string
+	KeyType         KeyType
 }
 
 type KeyType int8

--- a/internal/core/ports/factories/identity.go
+++ b/internal/core/ports/factories/identity.go
@@ -11,5 +11,6 @@ type IdentityFactory interface {
 
 type Identity interface {
 	GetProviderID() string
+	GetCookieFieldName() string
 	Identify(ctx context.Context, token string) (string, error)
 }


### PR DESCRIPTION
Add the option for custom providers to read the user's token from a specific field in the `Cookie` header instead of from  `Authorization`.

Expand Custom Providers with an additional field, `cookie_field_name`, containing the name of such field.

As for RFC 6265, there's no standard name for token fields (and it's a bit weird and unusual sending them there anyway). In any case, some auth frontend solutions seem to prefer sending the token through there, so we're introducing this change in hopes of reducing friction in these specific cases.