### PR TITLE
Fix shares put request

### DIFF
--- a/internal/adapters/handlers/rest/sharehdl/handler.go
+++ b/internal/adapters/handlers/rest/sharehdl/handler.go
@@ -186,7 +186,7 @@ func (h *Handler) UpdateShare(w http.ResponseWriter, r *http.Request) {
 	if req.EncryptionSession != "" {
 		opts = append(opts, shareapp.WithEncryptionSession(req.EncryptionSession))
 	}
-	shr, err := h.app.UpdateShare(ctx, share, opts...)
+	shr, err := h.app.UpdateShare(ctx, share, req.Reference, opts...)
 	if err != nil {
 		api.RespondWithError(w, fromApplicationError(err))
 		return

--- a/internal/applications/shareapp/app.go
+++ b/internal/applications/shareapp/app.go
@@ -78,12 +78,12 @@ func (a *ShareApplication) RegisterShare(ctx context.Context, shr *share.Share, 
 	return nil
 }
 
-func (a *ShareApplication) UpdateShare(ctx context.Context, shr *share.Share, opts ...Option) (*share.Share, error) {
+func (a *ShareApplication) UpdateShare(ctx context.Context, shr *share.Share, reference string, opts ...Option) (*share.Share, error) {
 	a.logger.InfoContext(ctx, "updating share")
 	usrID := contexter.GetUserID(ctx)
 	projID := contexter.GetProjectID(ctx)
 
-	dbShare, err := a.shareSvc.Find(ctx, usrID, nil, nil)
+	dbShare, err := a.shareSvc.Find(ctx, usrID, nil, &reference)
 	if err != nil {
 		a.logger.ErrorContext(ctx, "failed to get share by user ID", logger.Error(err))
 		return nil, fromDomainError(err)

--- a/internal/applications/shareapp/app_test.go
+++ b/internal/applications/shareapp/app_test.go
@@ -655,7 +655,7 @@ func TestShareApplication_UpdateShare(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.mock()
 			ass := assert.New(t)
-			_, err := app.UpdateShare(ctx, tt.updates)
+			_, err := app.UpdateShare(ctx, tt.updates, "default")
 			ass.ErrorIs(tt.wantErr, err)
 		})
 	}


### PR DESCRIPTION
# What
This PR fixes a bug which occurs for new accounts which have reference not default but signer id. The issue is that current `UpdateShare()` doesn't use reference which was sent in the request even though we pass there reference. In this PR is added utilisation of that field.