### PR TITLE
fix: entropy db conversion

### DIFF
--- a/internal/adapters/repositories/sql/sharerepo/parser.go
+++ b/internal/adapters/repositories/sql/sharerepo/parser.go
@@ -18,11 +18,13 @@ func newParser() *parser {
 			EntropyNone:    share.EntropyNone,
 			EntropyUser:    share.EntropyUser,
 			EntropyProject: share.EntropyProject,
+			EntropyPasskey: share.EntropyPasskey,
 		},
 		mapDomainEntropy: map[share.Entropy]Entropy{
 			share.EntropyNone:    EntropyNone,
 			share.EntropyUser:    EntropyUser,
 			share.EntropyProject: EntropyProject,
+			share.EntropyPasskey: EntropyPasskey,
 		},
 		mapDomainStorageMethod: map[share.StorageMethodID]ShareStorageMethodID{
 			share.StorageMethodShield:      StorageMethodShield,


### PR DESCRIPTION
Share entropy arrives as a string, gets converted to an int and then converted back to the original string in the DB layer. Go figure.

There was a missing parsing step between the domain and DB layer. Since parsers are maps they'll default to 0 (none).