### PR TITLE
feat: endpoint to retrieve legacy shares via external userID

### DIFF
--- a/internal/adapters/handlers/rest/server.go
+++ b/internal/adapters/handlers/rest/server.go
@@ -103,6 +103,7 @@ func (s *Server) Start(ctx context.Context) error {
 	e := u.PathPrefix("/encryption").Subrouter()
 	e.HandleFunc("", shareHdl.GetShareEncryption).Methods(http.MethodGet)
 	e.HandleFunc("/reference/bulk", shareHdl.GetSharesEncryptionForReferences).Methods(http.MethodPost)
+	e.HandleFunc("/user/bulk", shareHdl.GetSharesEncryptionForUsers).Methods(http.MethodPost)
 
 	a := r.PathPrefix("/admin").Subrouter()
 	a.Use(authMdw.AuthenticateAPISecret)

--- a/internal/adapters/handlers/rest/sharehdl/types.go
+++ b/internal/adapters/handlers/rest/sharehdl/types.go
@@ -83,3 +83,11 @@ type EncryptionTypeResponse struct {
 type GetSharesEncryptionForReferencesResponse struct {
 	EncryptionTypes map[string]EncryptionTypeResponse `json:"encryption_types"`
 }
+
+type GetSharesEncryptionForUsersRequest struct {
+	UserIDs []string `json:"user_ids"`
+}
+
+type GetSharesEncryptionForUsersResponse struct {
+	EncryptionTypes map[string]EncryptionTypeResponse `json:"encryption_types"`
+}

--- a/internal/adapters/repositories/mocks/sharemockrepo/repo.go
+++ b/internal/adapters/repositories/mocks/sharemockrepo/repo.go
@@ -88,3 +88,8 @@ func (m *MockShareRepository) GetSharesEncryptionForProjectAndReferences(ctx con
 	args := m.Mock.Called(ctx)
 	return args.Get(0).(map[string]share.Entropy), args.Error(1)
 }
+
+func (m *MockShareRepository) GetSharesEncryptionForProjectAndExternalUserIDs(ctx context.Context, projectID string, userIDs []string) (map[string]share.Entropy, error) {
+	args := m.Mock.Called(ctx)
+	return args.Get(0).(map[string]share.Entropy), args.Error(1)
+}

--- a/internal/adapters/repositories/sql/sharerepo/types.go
+++ b/internal/adapters/repositories/sql/sharerepo/types.go
@@ -58,3 +58,8 @@ type EntropyAndReference struct {
 	Entropy   Entropy
 	Reference string
 }
+
+type EntropyAndUserID struct {
+	Entropy Entropy
+	UserID  string
+}

--- a/internal/applications/shareapp/app.go
+++ b/internal/applications/shareapp/app.go
@@ -165,6 +165,22 @@ func (a *ShareApplication) GetSharesEncryptionForReferences(ctx context.Context,
 	return returnValue, nil
 }
 
+func (a *ShareApplication) GetSharesEncryptionForUsers(ctx context.Context, userIDs []string) (map[string]share.Entropy, error) {
+	// Same as in GetSharesEncryptionForReferences (right above this one)
+	projectID := contexter.GetProjectID(ctx)
+	// Small clarification: by userID we mean external userID here
+	// That is, the requester doesn't care of the internal ID of users as it doesn't ever leave Shield
+	// They care about the inferred user ID (usually via publishable key/JWT token)
+	returnValue, err := a.shareRepo.GetSharesEncryptionForProjectAndExternalUserIDs(ctx, projectID, userIDs)
+
+	if err != nil {
+		a.logger.ErrorContext(ctx, "Failed to retrieve encryption method for shares")
+		return nil, fromDomainError(err)
+	}
+
+	return returnValue, nil
+}
+
 func (a *ShareApplication) migrateToKeychainIfRequired(ctx context.Context, usrID string) (string, error) {
 	userKeychain, err := a.keychainRepository.GetByUserID(ctx, usrID)
 	if err != nil && !errors.Is(err, domainErrors.ErrKeychainNotFound) {

--- a/internal/core/ports/repositories/shares.go
+++ b/internal/core/ports/repositories/shares.go
@@ -19,4 +19,5 @@ type ShareRepository interface {
 	BulkUpdate(ctx context.Context, shrs []*share.Share) error
 	GetShareStorageMethods(ctx context.Context) ([]*share.StorageMethod, error)
 	GetSharesEncryptionForProjectAndReferences(ctx context.Context, projectID string, references []string) (map[string]share.Entropy, error)
+	GetSharesEncryptionForProjectAndExternalUserIDs(ctx context.Context, projectID string, userIDs []string) (map[string]share.Entropy, error)
 }


### PR DESCRIPTION
Similar to previous PR but for (external) user IDs.

Used as fallback method in case v2 method doesn't find associated share.