### PR TITLE
Fix http status code for liveness endpoint

### DIFF
--- a/internal/adapters/handlers/rest/healthzhdl/handler.go
+++ b/internal/adapters/handlers/rest/healthzhdl/handler.go
@@ -47,14 +47,15 @@ func (h *Handler) Healthz(w http.ResponseWriter, r *http.Request) {
 				Status: "unhealthy",
 			})
 		}
+		w.WriteHeader(http.StatusInternalServerError)
 	} else {
 		status.Checks = append(status.Checks, Check{
 			Name:   "database",
 			Status: "healthy",
 		})
+		w.WriteHeader(http.StatusOK)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(status)
 }

--- a/internal/adapters/handlers/rest/healthzhdl/handler.go
+++ b/internal/adapters/handlers/rest/healthzhdl/handler.go
@@ -47,7 +47,7 @@ func (h *Handler) Healthz(w http.ResponseWriter, r *http.Request) {
 				Status: "unhealthy",
 			})
 		}
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(http.StatusServiceUnavailable)
 	} else {
 		status.Checks = append(status.Checks, Check{
 			Name:   "database",


### PR DESCRIPTION
# What
This PR adds changes to the health endpoint which is used by Kube. The problem is that health endpoint always returns 200 status code and according to [Kube documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request) it identifies this service as ready to accept requests. With these changes status code will be either 200 or 500.