### PR TITLE
Fix bug with selecting share by reference

### DIFF
--- a/di/wire.go
+++ b/di/wire.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/wire"
 	"go.openfort.xyz/shield/internal/adapters/authenticators"
 	"go.openfort.xyz/shield/internal/adapters/authenticators/identity"
-	"go.openfort.xyz/shield/internal/adapters/authenticators/identity/openfort_identity"
+	ofidty "go.openfort.xyz/shield/internal/adapters/authenticators/identity/openfort_identity"
 	"go.openfort.xyz/shield/internal/adapters/encryption"
 	"go.openfort.xyz/shield/internal/adapters/handlers/rest"
 	"go.openfort.xyz/shield/internal/adapters/repositories/bunt"
@@ -166,6 +166,7 @@ func ProvideShareApplication() (a *shareapp.ShareApplication, err error) {
 		ProvideShareService,
 		ProvideSQLShareRepository,
 		ProvideSQLProjectRepository,
+		ProvideSQLUserRepository,
 		ProvideSQLKeychainRepository,
 		ProvideEncryptionFactory,
 		ProvideShamirJob,

--- a/di/wire_gen.go
+++ b/di/wire_gen.go
@@ -9,7 +9,7 @@ package di
 import (
 	"go.openfort.xyz/shield/internal/adapters/authenticators"
 	"go.openfort.xyz/shield/internal/adapters/authenticators/identity"
-	ofidty "go.openfort.xyz/shield/internal/adapters/authenticators/identity/openfort_identity"
+	"go.openfort.xyz/shield/internal/adapters/authenticators/identity/openfort_identity"
 	"go.openfort.xyz/shield/internal/adapters/encryption"
 	"go.openfort.xyz/shield/internal/adapters/handlers/rest"
 	"go.openfort.xyz/shield/internal/adapters/repositories/bunt"
@@ -192,6 +192,10 @@ func ProvideShareApplication() (*shareapp.ShareApplication, error) {
 	if err != nil {
 		return nil, err
 	}
+	userRepository, err := ProvideSQLUserRepository()
+	if err != nil {
+		return nil, err
+	}
 	keychainRepository, err := ProvideSQLKeychainRepository()
 	if err != nil {
 		return nil, err
@@ -204,7 +208,7 @@ func ProvideShareApplication() (*shareapp.ShareApplication, error) {
 	if err != nil {
 		return nil, err
 	}
-	shareApplication := shareapp.New(shareService, shareRepository, projectRepository, keychainRepository, encryptionFactory, job)
+	shareApplication := shareapp.New(shareService, shareRepository, projectRepository, userRepository, keychainRepository, encryptionFactory, job)
 	return shareApplication, nil
 }
 

--- a/internal/adapters/authenticators/user_authenticator/user_authenticator.go
+++ b/internal/adapters/authenticators/user_authenticator/user_authenticator.go
@@ -55,7 +55,8 @@ func (a *UserAuthenticator) Authenticate(ctx context.Context) (*authentication.A
 	}
 
 	return &authentication.Authentication{
-		UserID:    usr.ID,
-		ProjectID: proj.ID,
+		UserID:         usr.ID,
+		ProjectID:      proj.ID,
+		ExternalUserID: externalUserID,
 	}, nil
 }

--- a/internal/adapters/handlers/rest/authmdw/middleware.go
+++ b/internal/adapters/handlers/rest/authmdw/middleware.go
@@ -218,6 +218,7 @@ func (m *Middleware) AuthenticateUser(next http.Handler) http.Handler {
 
 		ctx := contexter.WithUserID(r.Context(), authentication.UserID)
 		ctx = contexter.WithProjectID(ctx, authentication.ProjectID)
+		ctx = contexter.WithExternalUserID(ctx, authentication.ExternalUserID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }

--- a/internal/adapters/handlers/rest/server.go
+++ b/internal/adapters/handlers/rest/server.go
@@ -96,6 +96,7 @@ func (s *Server) Start(ctx context.Context) error {
 	u := r.PathPrefix("/shares").Subrouter()
 	u.Use(authMdw.AuthenticateUser)
 	u.HandleFunc("", shareHdl.GetShare).Methods(http.MethodGet)
+	u.HandleFunc("/{reference}", shareHdl.GetShareByReference).Methods(http.MethodGet)
 
 	u.HandleFunc("", shareHdl.RegisterShare).Methods(http.MethodPost)
 	u.HandleFunc("", shareHdl.DeleteShare).Methods(http.MethodDelete)

--- a/internal/adapters/repositories/mocks/sharemockrepo/repo.go
+++ b/internal/adapters/repositories/mocks/sharemockrepo/repo.go
@@ -35,7 +35,15 @@ func (m *MockShareRepository) Get(ctx context.Context, shareID string) (*share.S
 	return args.Get(0).(*share.Share), args.Error(1)
 }
 
-func (m *MockShareRepository) GetByReference(ctx context.Context, reference, keychainID string) (*share.Share, error) {
+func (m *MockShareRepository) GetByReference(ctx context.Context, reference string) (*share.Share, error) {
+	args := m.Mock.Called(ctx, reference)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*share.Share), args.Error(1)
+}
+
+func (m *MockShareRepository) GetByReferenceAndKeychain(ctx context.Context, reference, keychainID string) (*share.Share, error) {
 	args := m.Mock.Called(ctx, reference, keychainID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)

--- a/internal/adapters/repositories/mocks/usermockedrepo/repo.go
+++ b/internal/adapters/repositories/mocks/usermockedrepo/repo.go
@@ -53,3 +53,11 @@ func (m *MockUserRepository) CreateExternal(ctx context.Context, extUsr *user.Ex
 	args := m.Mock.Called(ctx, extUsr)
 	return args.Error(0)
 }
+
+func (m *MockUserRepository) GetUserIDsByExternalID(ctx context.Context, externalUserID string) ([]string, error) {
+	args := m.Mock.Called(ctx, externalUserID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]string), args.Error(1)
+}

--- a/internal/applications/shareapp/app.go
+++ b/internal/applications/shareapp/app.go
@@ -309,7 +309,7 @@ func (a *ShareApplication) GetKeychainShares(ctx context.Context, reference *str
 }
 
 func (a *ShareApplication) GetShareByReference(ctx context.Context, reference string, opts ...Option) (*share.Share, error) {
-	a.logger.InfoContext(ctx, "getting keychain shares")
+	a.logger.InfoContext(ctx, "getting share by reference")
 	externalUserID := contexter.GetExternalUserID(ctx)
 
 	var opt options

--- a/internal/applications/shareapp/app_test.go
+++ b/internal/applications/shareapp/app_test.go
@@ -241,6 +241,252 @@ func TestShareApplication_GetShare(t *testing.T) {
 	}
 }
 
+func TestShareApplication_GetShareByReference(t *testing.T) {
+	ctx := contexter.WithProjectID(context.Background(), "project_id")
+	ctx = contexter.WithUserID(ctx, "user_id")
+	userRepo := new(usermockedrepo.MockUserRepository)
+	shareRepo := new(sharemockrepo.MockShareRepository)
+	projectRepo := new(projectmockrepo.MockProjectRepository)
+	encryptionPartsRepo := new(encryptionpartsmockrepo.MockEncryptionPartsRepository)
+	encryptionFactory := encryption.NewEncryptionFactory(encryptionPartsRepo, projectRepo)
+	keychainRepo := new(keychainmockrepo.MockKeychainRepository)
+	shareSvc := sharesvc.New(shareRepo, keychainRepo, encryptionFactory)
+	app := New(shareSvc, shareRepo, projectRepo, userRepo, keychainRepo, encryptionFactory, &shamirjob.Job{})
+	key, err := random.GenerateRandomString(32)
+	if err != nil {
+		t.Fatalf(key)
+	}
+
+	reconstructor := encryptionFactory.CreateReconstructionStrategy(true)
+	storedPart, projectPart, err := reconstructor.Split(key)
+	if err != nil {
+		t.Fatalf("failed to generate encryption key: %v", err)
+	}
+
+	cypher := encryptionFactory.CreateEncryptionStrategy(key)
+	encryptedSecret, err := cypher.Encrypt("secret")
+	if err != nil {
+		t.Fatalf("failed to cypher secret: %v", err)
+	}
+
+	userID := "user_id"
+
+	plainShare := &share.Share{
+		Secret:  "secret",
+		Entropy: share.EntropyNone,
+		UserID:  userID,
+	}
+	encryptedShare := &share.Share{
+		Secret:  encryptedSecret,
+		Entropy: share.EntropyProject,
+		UserID:  userID,
+	}
+	decryptedShare := &share.Share{
+		Secret:  "secret",
+		Entropy: share.EntropyProject,
+		UserID:  userID,
+	}
+
+	reference := "sig_reference"
+
+	tc := []struct {
+		name    string
+		opts    []Option
+		wantErr error
+		want    *share.Share
+		mock    func()
+	}{
+		{
+			name:    "success",
+			wantErr: nil,
+			want:    plainShare,
+			mock: func() {
+				shareRepo.ExpectedCalls = nil
+				projectRepo.ExpectedCalls = nil
+				userRepo.ExpectedCalls = nil
+				shareRepo.On("GetByReference", mock.Anything, reference).Return(plainShare, nil)
+				userRepo.On("GetUserIDsByExternalID", mock.Anything, mock.Anything).Return([]string{userID}, nil)
+			},
+		},
+		{
+			name:    "encrypted success",
+			wantErr: nil,
+			want:    decryptedShare,
+			mock: func() {
+				tmpEncryptedShare := *encryptedShare
+				shareRepo.ExpectedCalls = nil
+				projectRepo.ExpectedCalls = nil
+				userRepo.ExpectedCalls = nil
+				shareRepo.On("GetByReference", mock.Anything, reference).Return(&tmpEncryptedShare, nil)
+				userRepo.On("GetUserIDsByExternalID", mock.Anything, mock.Anything).Return([]string{userID}, nil)
+				projectRepo.On("GetEncryptionPart", mock.Anything, "project_id").Return(storedPart, nil)
+				projectRepo.On("HasSuccessfulMigration", mock.Anything, "project_id").Return(true, nil)
+			},
+			opts: []Option{
+				WithEncryptionPart(projectPart),
+			},
+		},
+		{
+			name:    "encrypted success with session",
+			wantErr: nil,
+			want:    decryptedShare,
+			mock: func() {
+				tmpEncryptedShare := *encryptedShare
+				shareRepo.ExpectedCalls = nil
+				projectRepo.ExpectedCalls = nil
+				encryptionPartsRepo.ExpectedCalls = nil
+				userRepo.ExpectedCalls = nil
+				shareRepo.On("GetByReference", mock.Anything, reference).Return(&tmpEncryptedShare, nil)
+				userRepo.On("GetUserIDsByExternalID", mock.Anything, mock.Anything).Return([]string{userID}, nil)
+				projectRepo.On("GetEncryptionPart", mock.Anything, "project_id").Return(storedPart, nil)
+				encryptionPartsRepo.On("Get", mock.Anything, "sessionID").Return(projectPart, nil)
+				encryptionPartsRepo.On("Delete", mock.Anything, "sessionID").Return(nil)
+				projectRepo.On("HasSuccessfulMigration", mock.Anything, "project_id").Return(true, nil)
+
+			},
+			opts: []Option{
+				WithEncryptionSession("sessionID"),
+			},
+		},
+		{
+			name:    "encryption part required",
+			wantErr: ErrEncryptionPartRequired,
+			mock: func() {
+				tmpEncryptedShare := *encryptedShare
+				shareRepo.ExpectedCalls = nil
+				projectRepo.ExpectedCalls = nil
+				shareRepo.On("GetByReference", mock.Anything, reference).Return(&tmpEncryptedShare, nil)
+			},
+		},
+		{
+			name:    "encryption not configured",
+			wantErr: ErrEncryptionNotConfigured,
+			mock: func() {
+				tmpEncryptedShare := *encryptedShare
+				shareRepo.ExpectedCalls = nil
+				projectRepo.ExpectedCalls = nil
+				userRepo.ExpectedCalls = nil
+				shareRepo.On("GetByReference", mock.Anything, reference).Return(&tmpEncryptedShare, nil)
+				userRepo.On("GetUserIDsByExternalID", mock.Anything, mock.Anything).Return([]string{userID}, nil)
+				projectRepo.On("GetEncryptionPart", mock.Anything, "project_id").Return("", domainErrors.ErrEncryptionPartNotFound)
+				projectRepo.On("HasSuccessfulMigration", mock.Anything, "project_id").Return(true, nil)
+
+			},
+			opts: []Option{
+				WithEncryptionPart(projectPart),
+			},
+		},
+		{
+			name:    "invalid encryption part",
+			wantErr: ErrInvalidEncryptionPart,
+			mock: func() {
+				tmpEncryptedShare := *encryptedShare
+				shareRepo.ExpectedCalls = nil
+				projectRepo.ExpectedCalls = nil
+				userRepo.ExpectedCalls = nil
+				shareRepo.On("GetByReference", mock.Anything, reference).Return(&tmpEncryptedShare, nil)
+				userRepo.On("GetUserIDsByExternalID", mock.Anything, mock.Anything).Return([]string{userID}, nil)
+				projectRepo.On("GetEncryptionPart", mock.Anything, "project_id").Return(storedPart, nil)
+				projectRepo.On("HasSuccessfulMigration", mock.Anything, "project_id").Return(true, nil)
+			},
+			opts: []Option{
+				WithEncryptionPart("invalid-key"),
+			},
+		},
+		{
+			name:    "decryption error",
+			wantErr: ErrInternal,
+			mock: func() {
+				shareRepo.ExpectedCalls = nil
+				projectRepo.ExpectedCalls = nil
+				userRepo.ExpectedCalls = nil
+				shareRepo.On("GetByReference", mock.Anything, reference).Return(decryptedShare, nil)
+				userRepo.On("GetUserIDsByExternalID", mock.Anything, mock.Anything).Return([]string{userID}, nil)
+				projectRepo.On("GetEncryptionPart", mock.Anything, "project_id").Return(storedPart, nil)
+				projectRepo.On("HasSuccessfulMigration", mock.Anything, "project_id").Return(true, nil)
+			},
+			opts: []Option{
+				WithEncryptionPart(projectPart),
+			},
+		},
+		{
+			name:    "share not found",
+			wantErr: ErrShareNotFound,
+			mock: func() {
+				shareRepo.ExpectedCalls = nil
+				projectRepo.ExpectedCalls = nil
+				shareRepo.On("GetByReference", mock.Anything, reference).Return(nil, domainErrors.ErrShareNotFound)
+				shareRepo.On("GetByReferenceAndKeychain", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
+			},
+		},
+		{
+			name:    "share does not belong to user",
+			wantErr: ErrShareNotFound,
+			mock: func() {
+				shareRepo.ExpectedCalls = nil
+				projectRepo.ExpectedCalls = nil
+				userRepo.ExpectedCalls = nil
+				userRepo.ExpectedCalls = nil
+				shareRepo.On("GetByReference", mock.Anything, reference).Return(plainShare, nil)
+				userRepo.On("GetUserIDsByExternalID", mock.Anything, mock.Anything).Return([]string{"random_user_id"}, nil)
+			},
+		},
+		{
+			name:    "get share repository error",
+			wantErr: ErrInternal,
+			mock: func() {
+				shareRepo.ExpectedCalls = nil
+				projectRepo.ExpectedCalls = nil
+				shareRepo.On("GetByReference", mock.Anything, reference).Return(nil, errors.New("repository error"))
+			},
+		},
+		{
+			name:    "get encryption part repository error",
+			wantErr: ErrInternal,
+			mock: func() {
+				tmpEncryptedShare := *encryptedShare
+				shareRepo.ExpectedCalls = nil
+				projectRepo.ExpectedCalls = nil
+				userRepo.ExpectedCalls = nil
+				shareRepo.On("GetByReference", mock.Anything, reference).Return(&tmpEncryptedShare, nil)
+				userRepo.On("GetUserIDsByExternalID", mock.Anything, mock.Anything).Return([]string{userID}, nil)
+				projectRepo.On("GetEncryptionPart", mock.Anything, "project_id").Return("", errors.New("repository error"))
+				projectRepo.On("HasSuccessfulMigration", mock.Anything, "project_id").Return(true, nil)
+			},
+			opts: []Option{
+				WithEncryptionPart(projectPart),
+			},
+		},
+		{
+			name:    "encryption part not found",
+			wantErr: ErrEncryptionNotConfigured,
+			mock: func() {
+				tmpEncryptedShare := *encryptedShare
+				shareRepo.ExpectedCalls = nil
+				projectRepo.ExpectedCalls = nil
+				userRepo.ExpectedCalls = nil
+				shareRepo.On("GetByReference", mock.Anything, reference).Return(&tmpEncryptedShare, nil)
+				userRepo.On("GetUserIDsByExternalID", mock.Anything, mock.Anything).Return([]string{userID}, nil)
+				projectRepo.On("GetEncryptionPart", mock.Anything, "project_id").Return("", domainErrors.ErrEncryptionPartNotFound)
+				projectRepo.On("HasSuccessfulMigration", mock.Anything, "project_id").Return(true, nil)
+			},
+			opts: []Option{
+				WithEncryptionPart(projectPart),
+			},
+		},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.mock()
+			ass := assert.New(t)
+			s, err := app.GetShareByReference(ctx, reference, tt.opts...)
+			ass.ErrorIs(err, tt.wantErr)
+			ass.Equal(tt.want, s)
+		})
+	}
+}
+
 func TestShareApplication_GetShareEncryption(t *testing.T) {
 	ctx := contexter.WithProjectID(context.Background(), "project_id")
 	ctx = contexter.WithUserID(ctx, "user_id")

--- a/internal/core/domain/authentication/authentication.go
+++ b/internal/core/domain/authentication/authentication.go
@@ -1,6 +1,7 @@
 package authentication
 
 type Authentication struct {
-	UserID    string
-	ProjectID string
+	UserID         string
+	ProjectID      string
+	ExternalUserID string
 }

--- a/internal/core/ports/repositories/shares.go
+++ b/internal/core/ports/repositories/shares.go
@@ -10,7 +10,8 @@ type ShareRepository interface {
 	Create(ctx context.Context, shr *share.Share) error
 	Get(ctx context.Context, shareID string) (*share.Share, error)
 	GetByUserID(ctx context.Context, userID string) (*share.Share, error)
-	GetByReference(ctx context.Context, reference, keychainID string) (*share.Share, error)
+	GetByReference(ctx context.Context, reference string) (*share.Share, error)
+	GetByReferenceAndKeychain(ctx context.Context, reference, keychainID string) (*share.Share, error)
 	Delete(ctx context.Context, shareID string) error
 	ListByKeychainID(ctx context.Context, keychainID string) ([]*share.Share, error)
 	ListProjectIDAndEntropy(ctx context.Context, projectID string, entropy share.Entropy) ([]*share.Share, error)

--- a/internal/core/ports/repositories/user.go
+++ b/internal/core/ports/repositories/user.go
@@ -16,6 +16,8 @@ type UserRepository interface {
 	WithUserID(userID string) Option
 	WithExternalUserID(externalUserID string) Option
 	WithProviderID(providerID string) Option
+
+	GetUserIDsByExternalID(ctx context.Context, externalUserID string) ([]string, error)
 }
 
 type Option func(Options)

--- a/internal/core/services/sharesvc/svc.go
+++ b/internal/core/services/sharesvc/svc.go
@@ -111,10 +111,10 @@ func (s *service) Find(ctx context.Context, userID string, keychainID, reference
 	}
 
 	if reference == nil {
-		return s.repo.GetByReference(ctx, share.DefaultReference, *keychainID)
+		return s.repo.GetByReferenceAndKeychain(ctx, share.DefaultReference, *keychainID)
 	}
 
-	return s.repo.GetByReference(ctx, *reference, *keychainID)
+	return s.repo.GetByReferenceAndKeychain(ctx, *reference, *keychainID)
 }
 
 func (s *service) validateKeychain(ctx context.Context, shr *share.Share) error {

--- a/internal/core/services/sharesvc/svc_test.go
+++ b/internal/core/services/sharesvc/svc_test.go
@@ -96,7 +96,7 @@ func TestCreateShare(t *testing.T) {
 				mockShareRepo.ExpectedCalls = nil
 				mockKeychainRepo.ExpectedCalls = nil
 				mockShareRepo.On("GetByUserID", mock.Anything, testUserID).Return(nil, domainErrors.ErrShareNotFound)
-				mockShareRepo.On("GetByReference", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
+				mockShareRepo.On("GetByReferenceAndKeychain", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
 				mockKeychainRepo.On("GetByUserID", mock.Anything, testUserID).Return(testKeychain, nil)
 				mockShareRepo.On("Create", mock.Anything, mock.AnythingOfType("*share.Share")).Return(nil)
 			},
@@ -108,7 +108,7 @@ func TestCreateShare(t *testing.T) {
 			mock: func() {
 				mockShareRepo.ExpectedCalls = nil
 				mockKeychainRepo.ExpectedCalls = nil
-				mockShareRepo.On("GetByReference", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
+				mockShareRepo.On("GetByReferenceAndKeychain", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
 				mockKeychainRepo.On("Get", mock.Anything, testKeychainID).Return(testKeychain, nil)
 				mockShareRepo.On("Create", mock.Anything, mock.AnythingOfType("*share.Share")).Return(nil)
 			},
@@ -121,7 +121,7 @@ func TestCreateShare(t *testing.T) {
 				mockShareRepo.ExpectedCalls = nil
 				mockKeychainRepo.ExpectedCalls = nil
 				mockShareRepo.On("GetByUserID", mock.Anything, testUserID).Return(nil, domainErrors.ErrShareNotFound)
-				mockShareRepo.On("GetByReference", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
+				mockShareRepo.On("GetByReferenceAndKeychain", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
 				mockKeychainRepo.On("GetByUserID", mock.Anything, testUserID).Return(nil, domainErrors.ErrKeychainNotFound)
 				mockKeychainRepo.On("Create", mock.Anything, mock.AnythingOfType("*keychain.Keychain")).Return(nil).Run(func(args mock.Arguments) {
 					kc := args.Get(1).(*keychain.Keychain)
@@ -140,7 +140,7 @@ func TestCreateShare(t *testing.T) {
 				mockShareRepo.ExpectedCalls = nil
 				mockKeychainRepo.ExpectedCalls = nil
 				mockShareRepo.On("GetByUserID", mock.Anything, testUserID).Return(nil, domainErrors.ErrShareNotFound)
-				mockShareRepo.On("GetByReference", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
+				mockShareRepo.On("GetByReferenceAndKeychain", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
 				mockKeychainRepo.On("GetByUserID", mock.Anything, testUserID).Return(testKeychain, nil)
 				mockShareRepo.On("Create", mock.Anything, mock.AnythingOfType("*share.Share")).Return(nil)
 			},
@@ -156,7 +156,7 @@ func TestCreateShare(t *testing.T) {
 				mockShareRepo.ExpectedCalls = nil
 				mockKeychainRepo.ExpectedCalls = nil
 				mockShareRepo.On("GetByUserID", mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
-				mockShareRepo.On("GetByReference", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
+				mockShareRepo.On("GetByReferenceAndKeychain", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
 				mockKeychainRepo.On("GetByUserID", mock.Anything, mock.Anything).Return(testKeychain, nil)
 			},
 			err: domainErrors.ErrEncryptionPartRequired,
@@ -170,7 +170,7 @@ func TestCreateShare(t *testing.T) {
 				mockKeychainRepo.ExpectedCalls = nil
 				mockShareRepo.On("GetByUserID", mock.Anything, testUserID).Return(nil, domainErrors.ErrShareNotFound)
 				mockShareRepo.On("GetByUserID", mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
-				mockShareRepo.On("GetByReference", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
+				mockShareRepo.On("GetByReferenceAndKeychain", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
 				mockKeychainRepo.On("GetByUserID", mock.Anything, mock.Anything).Return(testKeychain, nil)
 
 			},
@@ -202,7 +202,7 @@ func TestCreateShare(t *testing.T) {
 				}
 				mockKeychainRepo.On("Get", mock.Anything, testKeychainID).Return(wrongUserKeychain, nil)
 				mockShareRepo.On("GetByUserID", mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
-				mockShareRepo.On("GetByReference", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
+				mockShareRepo.On("GetByReferenceAndKeychain", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
 				mockKeychainRepo.On("GetByUserID", mock.Anything, mock.Anything).Return(testKeychain, nil)
 
 			},
@@ -217,7 +217,7 @@ func TestCreateShare(t *testing.T) {
 				mockKeychainRepo.ExpectedCalls = nil
 				mockKeychainRepo.On("Get", mock.Anything, testKeychainID).Return(nil, errors.New("repository error"))
 				mockShareRepo.On("GetByUserID", mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
-				mockShareRepo.On("GetByReference", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
+				mockShareRepo.On("GetByReferenceAndKeychain", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
 				mockKeychainRepo.On("GetByUserID", mock.Anything, mock.Anything).Return(testKeychain, nil)
 
 			},
@@ -253,7 +253,7 @@ func TestCreateShare(t *testing.T) {
 				mockKeychainRepo.ExpectedCalls = nil
 				mockShareRepo.On("Create", mock.Anything, mock.AnythingOfType("*share.Share")).Return(errors.New("repository error"))
 				mockShareRepo.On("GetByUserID", mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
-				mockShareRepo.On("GetByReference", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
+				mockShareRepo.On("GetByReferenceAndKeychain", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
 				mockKeychainRepo.On("GetByUserID", mock.Anything, mock.Anything).Return(testKeychain, nil)
 
 			},
@@ -329,7 +329,7 @@ func TestFindShare(t *testing.T) {
 			expected:   testShare,
 			mock: func() {
 				mockShareRepo.ExpectedCalls = nil
-				mockShareRepo.On("GetByReference", mock.Anything, mock.Anything, mock.Anything).Return(testShare, nil)
+				mockShareRepo.On("GetByReferenceAndKeychain", mock.Anything, mock.Anything, mock.Anything).Return(testShare, nil)
 			},
 		},
 		{
@@ -341,7 +341,7 @@ func TestFindShare(t *testing.T) {
 			expected:   testShare,
 			mock: func() {
 				mockShareRepo.ExpectedCalls = nil
-				mockShareRepo.On("GetByReference", mock.Anything, mock.Anything, mock.Anything).Return(testShare, nil)
+				mockShareRepo.On("GetByReferenceAndKeychain", mock.Anything, mock.Anything, mock.Anything).Return(testShare, nil)
 			},
 		},
 		{
@@ -355,7 +355,7 @@ func TestFindShare(t *testing.T) {
 				mockShareRepo.ExpectedCalls = nil
 				mockKeychainRepo.ExpectedCalls = nil
 				mockShareRepo.On("GetByUserID", mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
-				mockShareRepo.On("GetByReference", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
+				mockShareRepo.On("GetByReferenceAndKeychain", mock.Anything, mock.Anything, mock.Anything).Return(nil, domainErrors.ErrShareNotFound)
 				mockKeychainRepo.On("GetByUserID", mock.Anything, mock.Anything).Return(testKeychain, nil)
 			},
 		},

--- a/pkg/contexter/context.go
+++ b/pkg/contexter/context.go
@@ -32,8 +32,21 @@ func WithUserID(ctx context.Context, userID string) context.Context {
 	return context.WithValue(ctx, ContextKeyUserID, userID)
 }
 
+func WithExternalUserID(ctx context.Context, externalUserID string) context.Context {
+	return context.WithValue(ctx, ContextExternalUserID, externalUserID)
+}
+
 func GetUserID(ctx context.Context) string {
 	userID, ok := ctx.Value(ContextKeyUserID).(string)
+	if !ok {
+		return ""
+	}
+
+	return userID
+}
+
+func GetExternalUserID(ctx context.Context) string {
+	userID, ok := ctx.Value(ContextExternalUserID).(string)
 	if !ok {
 		return ""
 	}

--- a/pkg/contexter/keys.go
+++ b/pkg/contexter/keys.go
@@ -3,9 +3,10 @@ package contexter
 type ContextKey string
 
 const (
-	ContextKeyRequestID ContextKey = "request-id"
-	ContextKeyProjectID ContextKey = "project-id"
-	ContextKeyAPIKey    ContextKey = "api-key"
-	ContextKeyAPISecret ContextKey = "api-secret"
-	ContextKeyUserID    ContextKey = "user-id"
+	ContextKeyRequestID   ContextKey = "request-id"
+	ContextKeyProjectID   ContextKey = "project-id"
+	ContextKeyAPIKey      ContextKey = "api-key"
+	ContextKeyAPISecret   ContextKey = "api-secret"
+	ContextKeyUserID      ContextKey = "user-id"
+	ContextExternalUserID ContextKey = "external-user-id"
 )


### PR DESCRIPTION
# What
This PR fixes a bug which happens only in case one external user has two shield accounts and each of that accounts has own keychain. Usually it's not happening though.

# Why
So if user has two accounts and two keychains and he wants to select cold share by reference for key reconstruction API now may select a wrong shield user on the middleware level, and then as a result select wrong keychain which doesn't related to the share with reference which was sent in API method arguments.

It means that API throws share not found error.

# How
With these changes we start to save external user ID to the context, on the middleware level. And it adds a new endpoint to select a share by reference.

Once we selected a share by reference we check if external user really owns it and if yes return it.