### PR TITLE
Add OTP generation rate limits per project

### DIFF
--- a/internal/adapters/handlers/rest/api/errors.go
+++ b/internal/adapters/handlers/rest/api/errors.go
@@ -58,6 +58,7 @@ var (
 
 	ErrOTPRequired          = &Error{"OTP is required for this request", "OTP_MISSING", http.StatusPreconditionRequired}
 	ErrOTPRateLimitExceeded = &Error{"Rate limit exceeded for user to generate OTP", "OTP_RATE_LIMIT", http.StatusTooManyRequests}
+	ErrOTPProjectRateLimit  = &Error{"Rate limit per project exceeded to generate OTP", "OTP_PER_PROJECT_LIMIT", http.StatusTooManyRequests}
 	ErrOTPExpired           = &Error{"OTP is expired", "OTP_EXPIRED", http.StatusUnprocessableEntity}
 	ErrOTPInvalidated       = &Error{"OTP invalidated after max failed attempts", "OTP_INVALIDATED", http.StatusBadRequest}
 	ErrOTPInvalid           = &Error{"Received otp is invalid", "OTP_INVALID", http.StatusBadRequest}

--- a/internal/adapters/handlers/rest/projecthdl/errors.go
+++ b/internal/adapters/handlers/rest/projecthdl/errors.go
@@ -45,6 +45,8 @@ func fromApplicationError(err error) *api.Error {
 		return api.ErrOTPRequired
 	case errors.Is(err, projectapp.ErrOTPRateLimitExceeded):
 		return api.ErrOTPRateLimitExceeded
+	case errors.Is(err, projectapp.ErrOTPProjectRateLimit):
+		return api.ErrOTPProjectRateLimit
 	case errors.Is(err, projectapp.ErrOTPExpired):
 		return api.ErrOTPExpired
 	case errors.Is(err, projectapp.ErrOTPInvalidated):

--- a/internal/adapters/repositories/mocks/projectmockrepo/repo.go
+++ b/internal/adapters/repositories/mocks/projectmockrepo/repo.go
@@ -32,12 +32,12 @@ func (m *MockProjectRepository) Get(ctx context.Context, projectID string) (*pro
 	return args.Get(0).(*project.Project), args.Error(1)
 }
 
-func (m *MockProjectRepository) GetWithRateLimit(ctx context.Context, projectID string) (*project.ProjectWithRateLimit, error) {
+func (m *MockProjectRepository) GetWithRateLimit(ctx context.Context, projectID string) (*project.WithRateLimit, error) {
 	args := m.Mock.Called(ctx, projectID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	return args.Get(0).(*project.ProjectWithRateLimit), args.Error(1)
+	return args.Get(0).(*project.WithRateLimit), args.Error(1)
 }
 
 func (m *MockProjectRepository) GetByAPIKey(ctx context.Context, apiKey string) (*project.Project, error) {

--- a/internal/adapters/repositories/mocks/projectmockrepo/repo.go
+++ b/internal/adapters/repositories/mocks/projectmockrepo/repo.go
@@ -19,12 +19,25 @@ func (m *MockProjectRepository) Create(ctx context.Context, proj *project.Projec
 	return args.Error(0)
 }
 
+func (m *MockProjectRepository) SaveProjectRateLimits(ctx context.Context, rateLimits *project.RateLimit) error {
+	args := m.Mock.Called(ctx, rateLimits)
+	return args.Error(0)
+}
+
 func (m *MockProjectRepository) Get(ctx context.Context, projectID string) (*project.Project, error) {
 	args := m.Mock.Called(ctx, projectID)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(*project.Project), args.Error(1)
+}
+
+func (m *MockProjectRepository) GetWithRateLimit(ctx context.Context, projectID string) (*project.ProjectWithRateLimit, error) {
+	args := m.Mock.Called(ctx, projectID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*project.ProjectWithRateLimit), args.Error(1)
 }
 
 func (m *MockProjectRepository) GetByAPIKey(ctx context.Context, apiKey string) (*project.Project, error) {

--- a/internal/adapters/repositories/sql/migrations/20250929150619_rate_limit_table.sql
+++ b/internal/adapters/repositories/sql/migrations/20250929150619_rate_limit_table.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS shld_rate_limit (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    project_id VARCHAR(36) NOT NULL,
+    requests_per_minute INT NOT NULL
+);
+
+ALTER TABLE shld_rate_limit ADD CONSTRAINT fk_shdl_rate_limit_project FOREIGN KEY (project_id) REFERENCES shld_projects(id) ON DELETE CASCADE;
+
+INSERT INTO shld_rate_limit (project_id, requests_per_minute)
+SELECT id, 50 FROM shld_projects WHERE deleted_at IS NULL;
+
+-- +goose StatementBegin
+-- +goose StatementEnd
+
+-- +goose Down
+DROP TABLE IF EXISTS shld_rate_limit;
+
+-- +goose StatementBegin
+-- +goose StatementEnd

--- a/internal/adapters/repositories/sql/projectrepo/parser.go
+++ b/internal/adapters/repositories/sql/projectrepo/parser.go
@@ -19,8 +19,8 @@ func (p *parser) toDomain(proj *Project) *project.Project {
 	}
 }
 
-func (p *parser) toDomainWithRateLimit(proj *ProjectWithRateLimit) *project.ProjectWithRateLimit {
-	return &project.ProjectWithRateLimit{
+func (p *parser) toDomainWithRateLimit(proj *ProjectWithRateLimit) *project.WithRateLimit {
+	return &project.WithRateLimit{
 		ID:        proj.ID,
 		Name:      proj.Name,
 		APIKey:    proj.APIKey,

--- a/internal/adapters/repositories/sql/projectrepo/parser.go
+++ b/internal/adapters/repositories/sql/projectrepo/parser.go
@@ -19,11 +19,29 @@ func (p *parser) toDomain(proj *Project) *project.Project {
 	}
 }
 
+func (p *parser) toDomainWithRateLimit(proj *ProjectWithRateLimit) *project.ProjectWithRateLimit {
+	return &project.ProjectWithRateLimit{
+		ID:        proj.ID,
+		Name:      proj.Name,
+		APIKey:    proj.APIKey,
+		APISecret: proj.APISecret,
+		Enable2FA: proj.Enable2FA,
+		RateLimit: proj.RateLimit,
+	}
+}
+
 func (p *parser) toDatabase(proj *project.Project) *Project {
 	return &Project{
 		ID:        proj.ID,
 		Name:      proj.Name,
 		APIKey:    proj.APIKey,
 		APISecret: proj.APISecret,
+	}
+}
+
+func (p *parser) toDatabaseRateLimits(rateLimits *project.RateLimit) *RateLimit {
+	return &RateLimit{
+		ProjectID:         rateLimits.ProjectID,
+		RequestsPerMinute: rateLimits.RequestsPerMinute,
 	}
 }

--- a/internal/adapters/repositories/sql/projectrepo/repo.go
+++ b/internal/adapters/repositories/sql/projectrepo/repo.go
@@ -77,7 +77,7 @@ func (r *repository) Get(ctx context.Context, projectID string) (*project.Projec
 	return r.parser.toDomain(dbProj), nil
 }
 
-func (r *repository) GetWithRateLimit(ctx context.Context, projectID string) (*project.ProjectWithRateLimit, error) {
+func (r *repository) GetWithRateLimit(ctx context.Context, projectID string) (*project.WithRateLimit, error) {
 	r.logger.InfoContext(ctx, "getting project with rate limit")
 
 	dbProj := &ProjectWithRateLimit{}

--- a/internal/adapters/repositories/sql/projectrepo/types.go
+++ b/internal/adapters/repositories/sql/projectrepo/types.go
@@ -17,8 +17,30 @@ type Project struct {
 	Enable2FA bool           `gorm:"column:enable_2fa"`
 }
 
+type ProjectWithRateLimit struct {
+	ID        string         `gorm:"column:id;primaryKey"`
+	Name      string         `gorm:"column:name"`
+	APIKey    string         `gorm:"column:api_key"`
+	APISecret string         `gorm:"column:api_secret"`
+	CreatedAt time.Time      `gorm:"column:created_at;autoCreateTime"`
+	UpdatedAt time.Time      `gorm:"column:updated_at;autoUpdateTime"`
+	DeletedAt gorm.DeletedAt `gorm:"column:deleted_at"`
+	Enable2FA bool           `gorm:"column:enable_2fa"`
+	RateLimit int64          `gorm:"column:requests_per_minute"`
+}
+
 func (Project) TableName() string {
 	return "shld_projects"
+}
+
+type RateLimit struct {
+	ID                int64  `gorm:"column:id;primaryKey"`
+	ProjectID         string `gorm:"column:project_id"`
+	RequestsPerMinute int64  `gorm:"column:requests_per_minute"`
+}
+
+func (RateLimit) TableName() string {
+	return "shld_rate_limit"
 }
 
 type EncryptionPart struct {

--- a/internal/applications/projectapp/errors.go
+++ b/internal/applications/projectapp/errors.go
@@ -23,6 +23,7 @@ var (
 	ErrInvalidPemCertificate          = errors.New("invalid PEM certificate")
 	ErrOTPRequired                    = errors.New("OTP is required for this request")
 	ErrOTPRateLimitExceeded           = errors.New("rate limit exceeded for user")
+	ErrOTPProjectRateLimit            = errors.New("rate limit per project exceeded")
 	ErrOTPFailedToGenerate            = errors.New("failed to generate OTP")
 	ErrOTPFailedToMarshal             = errors.New("failed to marshal OTP request")
 	ErrOTPExpired                     = errors.New("otp was expired")

--- a/internal/applications/projectapp/project_rate_limits.go
+++ b/internal/applications/projectapp/project_rate_limits.go
@@ -1,0 +1,122 @@
+package projectapp
+
+import (
+	"sync"
+	"time"
+)
+
+type Clock interface {
+	Now() time.Time
+}
+
+type RealClock struct{}
+
+func NewRealClock() RealClock {
+	return RealClock{}
+}
+
+func (c *RealClock) Now() time.Time {
+	return time.Now()
+}
+
+type RequestTracker struct {
+	mu       sync.RWMutex
+	requests map[string]*ProjectRequestData
+	cleanup  chan struct{}
+	done     chan struct{}
+	clock    Clock
+}
+
+type ProjectRequestData struct {
+	count  int64
+	window time.Time
+}
+
+func NewRequestTracker(clock Clock) *RequestTracker {
+	rt := &RequestTracker{
+		requests: make(map[string]*ProjectRequestData),
+		cleanup:  make(chan struct{}),
+		done:     make(chan struct{}),
+		clock:    clock,
+	}
+
+	go rt.cleanupWorker()
+	return rt
+}
+
+func (rt *RequestTracker) TrackRequest(projectID string, rateLimit int64) bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	now := rt.clock.Now()
+	currentWindow := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), 0, 0, now.Location())
+
+	data, exists := rt.requests[projectID]
+	if !exists || data.window.Before(currentWindow) {
+		rt.requests[projectID] = &ProjectRequestData{
+			count:  1,
+			window: currentWindow,
+		}
+		return true
+	}
+
+	if data.count >= rateLimit {
+		return false
+	}
+
+	data.count++
+	return true
+}
+
+func (rt *RequestTracker) GetRequestCount(projectID string) int64 {
+	rt.mu.RLock()
+	defer rt.mu.RUnlock()
+
+	data, exists := rt.requests[projectID]
+	if !exists {
+		return 0
+	}
+
+	now := rt.clock.Now()
+	currentWindow := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), 0, 0, now.Location())
+
+	if data.window.Before(currentWindow) {
+		return 0
+	}
+
+	return data.count
+}
+
+func (rt *RequestTracker) cleanupWorker() {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			rt.cleanupOldEntries()
+		case <-rt.cleanup:
+			rt.cleanupOldEntries()
+		case <-rt.done:
+			return
+		}
+	}
+}
+
+func (rt *RequestTracker) cleanupOldEntries() {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	now := rt.clock.Now()
+	currentWindow := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), 0, 0, now.Location())
+
+	for projectID, data := range rt.requests {
+		if data.window.Before(currentWindow) {
+			delete(rt.requests, projectID)
+		}
+	}
+}
+
+func (rt *RequestTracker) Close() {
+	close(rt.done)
+}

--- a/internal/core/domain/project/project.go
+++ b/internal/core/domain/project/project.go
@@ -10,7 +10,7 @@ type Project struct {
 	RateLimit      int64
 }
 
-type ProjectWithRateLimit struct {
+type WithRateLimit struct {
 	ID             string
 	Name           string
 	APIKey         string

--- a/internal/core/domain/project/project.go
+++ b/internal/core/domain/project/project.go
@@ -7,4 +7,20 @@ type Project struct {
 	APISecret      string
 	EncryptionPart string
 	Enable2FA      bool
+	RateLimit      int64
+}
+
+type ProjectWithRateLimit struct {
+	ID             string
+	Name           string
+	APIKey         string
+	APISecret      string
+	EncryptionPart string
+	Enable2FA      bool
+	RateLimit      int64
+}
+
+type RateLimit struct {
+	ProjectID         string
+	RequestsPerMinute int64
 }

--- a/internal/core/ports/repositories/project.go
+++ b/internal/core/ports/repositories/project.go
@@ -8,7 +8,9 @@ import (
 
 type ProjectRepository interface {
 	Create(ctx context.Context, project *project.Project) error
+	SaveProjectRateLimits(ctx context.Context, rateLimits *project.RateLimit) error
 	Get(ctx context.Context, projectID string) (*project.Project, error)
+	GetWithRateLimit(ctx context.Context, projectID string) (*project.ProjectWithRateLimit, error)
 	GetByAPIKey(ctx context.Context, apiKey string) (*project.Project, error)
 	Delete(ctx context.Context, projectID string) error
 

--- a/internal/core/ports/repositories/project.go
+++ b/internal/core/ports/repositories/project.go
@@ -10,7 +10,7 @@ type ProjectRepository interface {
 	Create(ctx context.Context, project *project.Project) error
 	SaveProjectRateLimits(ctx context.Context, rateLimits *project.RateLimit) error
 	Get(ctx context.Context, projectID string) (*project.Project, error)
-	GetWithRateLimit(ctx context.Context, projectID string) (*project.ProjectWithRateLimit, error)
+	GetWithRateLimit(ctx context.Context, projectID string) (*project.WithRateLimit, error)
 	GetByAPIKey(ctx context.Context, apiKey string) (*project.Project, error)
 	Delete(ctx context.Context, projectID string) error
 

--- a/internal/core/ports/services/project.go
+++ b/internal/core/ports/services/project.go
@@ -8,5 +8,6 @@ import (
 
 type ProjectService interface {
 	Create(ctx context.Context, name string, enable2fa bool) (*project.Project, error)
+	SaveProjectRateLimits(ctx context.Context, projectID string, rateLimit int64) error
 	SetEncryptionPart(ctx context.Context, projectID, part string) error
 }

--- a/internal/core/services/projectsvc/svc.go
+++ b/internal/core/services/projectsvc/svc.go
@@ -57,6 +57,22 @@ func (s *service) Create(ctx context.Context, name string, enable2fa bool) (*pro
 	return proj, nil
 }
 
+func (s *service) SaveProjectRateLimits(ctx context.Context, projectID string, rateLimit int64) error {
+	s.logger.InfoContext(ctx, "save project rate limits", slog.String("project", projectID))
+
+	projectRateLimit := &project.RateLimit{
+		ProjectID:         projectID,
+		RequestsPerMinute: rateLimit,
+	}
+
+	err := s.repo.SaveProjectRateLimits(ctx, projectRateLimit)
+	if err != nil {
+		s.logger.ErrorContext(ctx, "failed to save project rate limits", logger.Error(err))
+	}
+
+	return err
+}
+
 func (s *service) SetEncryptionPart(ctx context.Context, projectID, part string) error {
 	s.logger.InfoContext(ctx, "setting encryption part", slog.String("project_id", projectID))
 	ep, err := s.repo.GetEncryptionPart(ctx, projectID)


### PR DESCRIPTION
# What
This PR adds rate limits for OTP generation per project. For now it's hardcoded value and may be changed only manualy.

Also this PR introduces small change to OTP requests rate limiting for users, now we don't rate limit OTP requests which are landed with parameter `DangerouslySkipVerification` set to `true`.