### PR TITLE
Do not call db with empty input data

### DIFF
--- a/internal/adapters/repositories/sql/sharerepo/repo.go
+++ b/internal/adapters/repositories/sql/sharerepo/repo.go
@@ -276,6 +276,10 @@ func (r *repository) GetShareStorageMethods(ctx context.Context) ([]*share.Stora
 }
 
 func (r *repository) GetSharesEncryptionForProjectAndReferences(ctx context.Context, projectID string, references []string) (map[string]share.RecoveryInfo, error) {
+	if len(references) == 0 {
+		return map[string]share.RecoveryInfo{}, nil
+	}
+
 	var queryResult []InfoByReference
 	err := r.db.Table("shld_shares").
 		Select("shld_shares.reference AS reference, shld_shares.entropy AS entropy, shld_passkey_references.passkey_id AS passkey_id, shld_passkey_references.passkey_env AS passkey_env").
@@ -305,6 +309,10 @@ func (r *repository) GetSharesEncryptionForProjectAndReferences(ctx context.Cont
 }
 
 func (r *repository) GetSharesEncryptionForProjectAndExternalUserIDs(ctx context.Context, projectID string, userIDs []string, reference *string) (map[string]share.RecoveryInfo, error) {
+	if len(userIDs) == 0 {
+		return map[string]share.RecoveryInfo{}, nil
+	}
+
 	var queryResult []InfoByUserID
 	req := r.db.Table("shld_shares").
 		Select("shld_external_users.external_user_id AS user_id, shld_shares.entropy AS entropy, shld_passkey_references.passkey_id AS passkey_id, shld_passkey_references.passkey_env AS passkey_env").


### PR DESCRIPTION
# What
GetSharesEncryptionForProjectAndExternalUserIDs and GetSharesEncryptionForProjectAndReferences built and executed a query even when their ID slice was empty. GORM renders an empty slice passed to IN ? as IN (NULL), and Limit(len(userIDs)) became LIMIT 0, producing a query that matches no rows but still pays connection and planning overhead on every call (observed as a 413ms slow-query log).

Both methods now return an empty result map immediately when the input slice is empty, skipping the database round trip. The behavior is unchanged: the handler builds its response by iterating over the requested IDs, so empty input already maps to an empty response.