### PR TITLE
fix: share a single DB connection pool across the DI graph

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,14 @@ DB_NAME="shield"
 # DB_SSL_CERT=            # Path to client-cert.pem
 # DB_SSL_KEY=             # Path to client-key.pem
 
+# Connection pool tuning (per process). MaxOpenConns caps concurrent connections;
+# 0 means unlimited. Lifetime/idle-time recycle connections rather than leaving
+# them open forever.
+# DB_MAX_OPEN_CONNS=20
+# DB_MAX_IDLE_CONNS=5
+# DB_CONN_MAX_LIFETIME="30m"
+# DB_CONN_MAX_IDLE_TIME="5m"
+
 # REQUESTS_PER_SECOND: "100"
 # READ_TIMEOUT: "5s"
 # WRITE_TIMEOUT: "10s"

--- a/di/db.go
+++ b/di/db.go
@@ -1,0 +1,31 @@
+package di
+
+import (
+	"sync"
+
+	"github.com/openfort-xyz/shield/internal/adapters/repositories/sql"
+)
+
+// ProvideSQL returns a process-wide singleton SQL client. It is memoized so the
+// many repository/service/application injectors that depend on it all share a
+// single connection pool instead of each opening its own via gorm.Open.
+//
+// It is a plain provider (not a wire injector) so that Wire generates calls to
+// this memoized function rather than re-running sql.New for every dependent.
+func ProvideSQL() (*sql.Client, error) {
+	sqlOnce.Do(func() {
+		cfg, err := sql.GetConfigFromEnv()
+		if err != nil {
+			sqlErr = err
+			return
+		}
+		sqlClient, sqlErr = sql.New(cfg)
+	})
+	return sqlClient, sqlErr
+}
+
+var (
+	sqlOnce   sync.Once
+	sqlClient *sql.Client
+	sqlErr    error
+)

--- a/di/wire.go
+++ b/di/wire.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openfort-xyz/shield/internal/adapters/handlers/rest"
 	"github.com/openfort-xyz/shield/internal/adapters/repositories/bunt"
 	"github.com/openfort-xyz/shield/internal/adapters/repositories/bunt/encryptionpartsrepo"
-	"github.com/openfort-xyz/shield/internal/adapters/repositories/sql"
 	"github.com/openfort-xyz/shield/internal/adapters/repositories/sql/keychainrepo"
 	"github.com/openfort-xyz/shield/internal/adapters/repositories/sql/notificationsrepo"
 	"github.com/openfort-xyz/shield/internal/adapters/repositories/sql/projectrepo"
@@ -36,15 +35,6 @@ import (
 	"github.com/openfort-xyz/shield/internal/core/services/usersvc"
 	"github.com/openfort-xyz/shield/pkg/otp"
 )
-
-func ProvideSQL() (c *sql.Client, err error) {
-	wire.Build(
-		sql.New,
-		sql.GetConfigFromEnv,
-	)
-
-	return
-}
 
 func ProvideBuntDB() (c *bunt.Client, err error) {
 	wire.Build(

--- a/di/wire_gen.go
+++ b/di/wire_gen.go
@@ -14,7 +14,6 @@ import (
 	"github.com/openfort-xyz/shield/internal/adapters/handlers/rest"
 	"github.com/openfort-xyz/shield/internal/adapters/repositories/bunt"
 	"github.com/openfort-xyz/shield/internal/adapters/repositories/bunt/encryptionpartsrepo"
-	"github.com/openfort-xyz/shield/internal/adapters/repositories/sql"
 	"github.com/openfort-xyz/shield/internal/adapters/repositories/sql/keychainrepo"
 	"github.com/openfort-xyz/shield/internal/adapters/repositories/sql/notificationsrepo"
 	"github.com/openfort-xyz/shield/internal/adapters/repositories/sql/projectrepo"
@@ -39,18 +38,6 @@ import (
 )
 
 // Injectors from wire.go:
-
-func ProvideSQL() (*sql.Client, error) {
-	config, err := sql.GetConfigFromEnv()
-	if err != nil {
-		return nil, err
-	}
-	client, err := sql.New(config)
-	if err != nil {
-		return nil, err
-	}
-	return client, nil
-}
 
 func ProvideBuntDB() (*bunt.Client, error) {
 	client, err := bunt.New()

--- a/internal/adapters/repositories/sql/client.go
+++ b/internal/adapters/repositories/sql/client.go
@@ -32,6 +32,15 @@ func New(cfg *Config) (*Client, error) {
 		return nil, err
 	}
 
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, err
+	}
+	sqlDB.SetMaxOpenConns(cfg.MaxOpenConns)
+	sqlDB.SetMaxIdleConns(cfg.MaxIdleConns)
+	sqlDB.SetConnMaxLifetime(cfg.ConnMaxLifetime)
+	sqlDB.SetConnMaxIdleTime(cfg.ConnMaxIdleTime)
+
 	return &Client{db}, nil
 }
 

--- a/internal/adapters/repositories/sql/config.go
+++ b/internal/adapters/repositories/sql/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"time"
 
 	env "github.com/caarlos0/env/v10"
 )
@@ -24,6 +25,15 @@ type Config struct {
 	SSLKey      string `env:"DB_SSL_KEY"`       // Path to client-key.pem
 
 	TimeZone string `env:"DB_TIMEZONE" envDefault:"UTC"`
+
+	// Connection pool tuning. A zero MaxOpenConns means unlimited (the
+	// database/sql default), which lets a burst of concurrent queries exhaust
+	// Postgres. ConnMaxLifetime/ConnMaxIdleTime ensure connections are recycled
+	// rather than lingering forever.
+	MaxOpenConns    int           `env:"DB_MAX_OPEN_CONNS" envDefault:"20"`
+	MaxIdleConns    int           `env:"DB_MAX_IDLE_CONNS" envDefault:"5"`
+	ConnMaxLifetime time.Duration `env:"DB_CONN_MAX_LIFETIME" envDefault:"30m"`
+	ConnMaxIdleTime time.Duration `env:"DB_CONN_MAX_IDLE_TIME" envDefault:"5m"`
 }
 
 const migrationDirectory = "internal/adapters/repositories/sql/migrations"


### PR DESCRIPTION
## Problem

A running Shield process opens **25 separate Postgres connection pools**. Each `ProvideSQLxxxRepository` injector in the Wire graph calls `ProvideSQL()` independently, and `ProvideSQL()` runs `gorm.Open()` every time — 24 pools inside `ProvideRESTServer` plus 1 leaked migration pool. Because no pool limits were ever set, every pool used the `database/sql` defaults (`MaxOpenConns=0`/unlimited, `MaxIdleConns=2`, connections never expiring), which pinned a ~50-connection baseline per process and let it grow without bound under load.

This is what shows up as the ~53 connections per Shield instance.

## Fix

1. **Singleton client** (`di/db.go`): `ProvideSQL` is now a `sync.Once`-memoized provider instead of a Wire injector, so all injectors share one pool. Migration and server share the client, eliminating the leaked pool. `di/wire.go` no longer declares the injector; `wire_gen.go` was regenerated with `go generate` (`sql.New` is no longer reachable more than once).
2. **Pool limits** (`client.go` + `config.go`): sets `MaxOpenConns/MaxIdleConns/ConnMaxLifetime/ConnMaxIdleTime`, configurable via `DB_MAX_OPEN_CONNS` / `DB_MAX_IDLE_CONNS` / `DB_CONN_MAX_LIFETIME` / `DB_CONN_MAX_IDLE_TIME` (defaults 20 / 5 / 30m / 5m).

## Verification (against Postgres)

| Scenario | Before | After |
|---|---|---|
| Connections at idle boot | 25 | **1** |
| 200 concurrent `/healthz`, peak | unbounded | **2**, drained back |
| 100 concurrent queries, cap set to 5 | up to 100 | **exactly 5** |

`go vet` clean, full module builds, unit suite passes.

## Not included (separate follow-ups)

Two unrelated issues surfaced during investigation and are left for follow-up PRs: the `BulkUpdate` transaction in `sharerepo/repo.go` writes on `r.db` instead of the tx handle (no atomicity + doubles connection use), and the detached `context.WithoutCancel` shamir goroutine in `shareapp`.