### PR TITLE
fix(logging): stop logging expected not-found as ERROR, and make the log level configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
 PORT=8080
 METRICS_PORT=9090
 
+# Minimum level the application loggers emit: debug | info | warn | error.
+# Defaults to info. Set to debug to surface the expected-but-noisy outcomes,
+# such as share and external-user lookup misses, that are otherwise dropped.
+# LOG_LEVEL=info
+
 # Database Configuration (PostgreSQL)
 DB_HOST="localhost"
 DB_PORT=5432

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,6 +16,12 @@ func main() {
 		slog.Debug("No .env file found or error loading it", logger.Error(err))
 	}
 
+	// After godotenv, so LOG_LEVEL can come from .env as well as the environment.
+	// Loggers built before this point pick the new level up too.
+	if err := logger.ConfigureFromEnv(); err != nil {
+		slog.Warn("Ignoring invalid log level, defaulting to info", logger.Error(err))
+	}
+
 	slog.Info("Starting OpenFort Shield")
 	rootCmd := cli.NewCmdRoot()
 	if err := rootCmd.Execute(); err != nil {

--- a/internal/applications/shareapp/app.go
+++ b/internal/applications/shareapp/app.go
@@ -262,8 +262,8 @@ func (a *ShareApplication) GetKeychainShares(ctx context.Context, reference *str
 		shr, err := a.shareRepo.GetByReferenceAndKeychain(ctx, *reference, keychainID)
 		if err != nil {
 			if errors.Is(err, domainErrors.ErrShareNotFound) {
-				// Expected outcome, not a failure: surfaced to the caller as a 404.
-				a.logger.WarnContext(ctx, "share not found by reference", slog.String("reference", *reference))
+				// Not a failure: surfaced to the caller as a 404.
+				a.logger.WarnContext(ctx, "keychain share not found by reference", slog.String("reference", *reference), slog.String("keychain_id", keychainID))
 				return nil, fromDomainError(err)
 			}
 
@@ -358,7 +358,7 @@ func (a *ShareApplication) GetShareByReference(ctx context.Context, reference st
 	shr, err := a.shareRepo.GetByReference(ctx, reference)
 	if err != nil {
 		if errors.Is(err, domainErrors.ErrShareNotFound) {
-			// Expected outcome, not a failure: surfaced to the caller as a 404.
+			// Not a failure: surfaced to the caller as a 404.
 			a.logger.WarnContext(ctx, "share not found by reference", slog.String("reference", reference))
 			return nil, fromDomainError(err)
 		}

--- a/internal/applications/shareapp/app.go
+++ b/internal/applications/shareapp/app.go
@@ -261,6 +261,12 @@ func (a *ShareApplication) GetKeychainShares(ctx context.Context, reference *str
 	if reference != nil {
 		shr, err := a.shareRepo.GetByReferenceAndKeychain(ctx, *reference, keychainID)
 		if err != nil {
+			if errors.Is(err, domainErrors.ErrShareNotFound) {
+				// Expected outcome, not a failure: surfaced to the caller as a 404.
+				a.logger.WarnContext(ctx, "share not found by reference", slog.String("reference", *reference))
+				return nil, fromDomainError(err)
+			}
+
 			a.logger.ErrorContext(ctx, "failed to get share by reference", logger.Error(err))
 			return nil, fromDomainError(err)
 		}
@@ -351,6 +357,12 @@ func (a *ShareApplication) GetShareByReference(ctx context.Context, reference st
 
 	shr, err := a.shareRepo.GetByReference(ctx, reference)
 	if err != nil {
+		if errors.Is(err, domainErrors.ErrShareNotFound) {
+			// Expected outcome, not a failure: surfaced to the caller as a 404.
+			a.logger.WarnContext(ctx, "share not found by reference", slog.String("reference", reference))
+			return nil, fromDomainError(err)
+		}
+
 		a.logger.ErrorContext(ctx, "failed to get share by reference", logger.Error(err))
 		return nil, fromDomainError(err)
 	}

--- a/internal/applications/shareapp/logging_test.go
+++ b/internal/applications/shareapp/logging_test.go
@@ -1,0 +1,158 @@
+package shareapp
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/openfort-xyz/shield/internal/adapters/encryption"
+	"github.com/openfort-xyz/shield/internal/adapters/repositories/mocks/encryptionpartsmockrepo"
+	"github.com/openfort-xyz/shield/internal/adapters/repositories/mocks/keychainmockrepo"
+	"github.com/openfort-xyz/shield/internal/adapters/repositories/mocks/projectmockrepo"
+	"github.com/openfort-xyz/shield/internal/adapters/repositories/mocks/sharemockrepo"
+	"github.com/openfort-xyz/shield/internal/adapters/repositories/mocks/usermockedrepo"
+	"github.com/openfort-xyz/shield/internal/applications/shamirjob"
+	domainErrors "github.com/openfort-xyz/shield/internal/core/domain/errors"
+	"github.com/openfort-xyz/shield/internal/core/domain/keychain"
+	"github.com/openfort-xyz/shield/internal/core/services/sharesvc"
+	"github.com/openfort-xyz/shield/pkg/contexter"
+	"github.com/openfort-xyz/shield/pkg/logger/logtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// At the application layer a missing share is what the caller receives as a 404,
+// rather than a step inside a larger operation, so it stays visible at the
+// default level as a warning. A genuine repository failure keeps its error
+// record.
+func TestGetKeychainSharesLogsNotFoundAsWarning(t *testing.T) {
+	const (
+		userID    = "user_id"
+		projectID = "project_id"
+		reference = "test-reference"
+	)
+
+	tests := []struct {
+		name         string
+		lookupErr    error
+		wantErr      error
+		wantMessage  string
+		wantSeverity string
+	}{
+		{
+			name:         "missing share is a warning",
+			lookupErr:    domainErrors.ErrShareNotFound,
+			wantErr:      ErrShareNotFound,
+			wantMessage:  "keychain share not found by reference",
+			wantSeverity: "WARNING",
+		},
+		{
+			name:         "an unexpected repository error is still an error",
+			lookupErr:    errors.New("connection refused"),
+			wantErr:      ErrInternal,
+			wantMessage:  "failed to get share by reference",
+			wantSeverity: "ERROR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := logtest.Start(slog.LevelInfo)
+			defer rec.Stop()
+
+			keychainID := uuid.NewString()
+
+			shareRepo := new(sharemockrepo.MockShareRepository)
+			keychainRepo := new(keychainmockrepo.MockKeychainRepository)
+			projectRepo := new(projectmockrepo.MockProjectRepository)
+			userRepo := new(usermockedrepo.MockUserRepository)
+
+			// The user already has a keychain and no legacy share, so the call
+			// reaches the lookup under test without migrating anything.
+			keychainRepo.On("GetByUserID", mock.Anything, userID).
+				Return(&keychain.Keychain{ID: keychainID, UserID: userID}, nil)
+			shareRepo.On("GetByUserID", mock.Anything, userID).Return(nil, domainErrors.ErrShareNotFound)
+			shareRepo.On("GetByReferenceAndKeychain", mock.Anything, reference, keychainID).Return(nil, tt.lookupErr)
+
+			encryptionFactory := encryption.NewEncryptionFactory(
+				new(encryptionpartsmockrepo.MockEncryptionPartsRepository), projectRepo)
+
+			// Constructed inside the recorder, since New resolves its destination
+			// when it runs.
+			app := New(
+				sharesvc.New(shareRepo, keychainRepo, encryptionFactory),
+				shareRepo, projectRepo, userRepo, keychainRepo, encryptionFactory, &shamirjob.Job{},
+			)
+
+			ctx := contexter.WithProjectID(context.Background(), projectID)
+			ctx = contexter.WithUserID(ctx, userID)
+
+			ref := reference
+			shares, err := app.GetKeychainShares(ctx, &ref)
+			require.ErrorIs(t, err, tt.wantErr)
+			assert.Nil(t, shares)
+
+			got, found := rec.Find(tt.wantMessage)
+			require.True(t, found, "expected a %q record, got %v", tt.wantMessage, rec.Records())
+			assert.Equal(t, tt.wantSeverity, got.Severity)
+			assert.Equal(t, "share_application", got.Logger)
+
+			if tt.wantSeverity == "ERROR" {
+				assert.Equal(t, tt.lookupErr.Error(), got.Attr("error"),
+					"the error record must still carry the underlying cause")
+				return
+			}
+
+			assert.NotContains(t, rec.Severities(), "ERROR",
+				"a missing share must not produce an error record")
+			// Both application-layer sites used to log the same text under the same
+			// logger name, which made them indistinguishable in a query.
+			assert.Equal(t, reference, got.Attr("reference"))
+			assert.Equal(t, keychainID, got.Attr("keychain_id"))
+		})
+	}
+}
+
+// The sibling site, which has no keychain in play.
+func TestGetShareByReferenceLogsNotFoundAsWarning(t *testing.T) {
+	const (
+		externalUserID = "external_user_id"
+		projectID      = "project_id"
+		reference      = "test-reference"
+	)
+
+	rec := logtest.Start(slog.LevelInfo)
+	defer rec.Stop()
+
+	shareRepo := new(sharemockrepo.MockShareRepository)
+	keychainRepo := new(keychainmockrepo.MockKeychainRepository)
+	projectRepo := new(projectmockrepo.MockProjectRepository)
+	userRepo := new(usermockedrepo.MockUserRepository)
+	shareRepo.On("GetByReference", mock.Anything, reference).Return(nil, domainErrors.ErrShareNotFound)
+
+	encryptionFactory := encryption.NewEncryptionFactory(
+		new(encryptionpartsmockrepo.MockEncryptionPartsRepository), projectRepo)
+
+	app := New(
+		sharesvc.New(shareRepo, keychainRepo, encryptionFactory),
+		shareRepo, projectRepo, userRepo, keychainRepo, encryptionFactory, &shamirjob.Job{},
+	)
+
+	ctx := contexter.WithProjectID(context.Background(), projectID)
+	ctx = contexter.WithExternalUserID(ctx, externalUserID)
+
+	shr, err := app.GetShareByReference(ctx, reference)
+	require.ErrorIs(t, err, ErrShareNotFound)
+	assert.Nil(t, shr)
+
+	got, found := rec.Find("share not found by reference")
+	require.True(t, found, "expected a warning record, got %v", rec.Records())
+	assert.Equal(t, "WARNING", got.Severity)
+	assert.Equal(t, "share_application", got.Logger)
+	assert.Equal(t, reference, got.Attr("reference"))
+	assert.NotContains(t, rec.Severities(), "ERROR",
+		"a missing share must not produce an error record")
+}

--- a/internal/core/services/sharesvc/logging_test.go
+++ b/internal/core/services/sharesvc/logging_test.go
@@ -1,0 +1,120 @@
+package sharesvc
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/openfort-xyz/shield/internal/adapters/encryption"
+	"github.com/openfort-xyz/shield/internal/adapters/repositories/mocks/encryptionpartsmockrepo"
+	"github.com/openfort-xyz/shield/internal/adapters/repositories/mocks/keychainmockrepo"
+	"github.com/openfort-xyz/shield/internal/adapters/repositories/mocks/projectmockrepo"
+	"github.com/openfort-xyz/shield/internal/adapters/repositories/mocks/sharemockrepo"
+	domainErrors "github.com/openfort-xyz/shield/internal/core/domain/errors"
+	"github.com/openfort-xyz/shield/internal/core/domain/keychain"
+	"github.com/openfort-xyz/shield/internal/core/domain/share"
+	"github.com/openfort-xyz/shield/pkg/logger/logtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// Registering a share looks the reference up first and expects it to be missing,
+// so the miss is the success path and must not be reported as a failure. It stays
+// available under LOG_LEVEL=debug, and a genuine repository failure keeps its
+// error record.
+func TestCreateWithFreeReferenceLogsNoError(t *testing.T) {
+	const (
+		userID    = "test-user"
+		reference = "test-reference"
+	)
+
+	keychainID := uuid.NewString()
+
+	tests := []struct {
+		name         string
+		lookupErr    error
+		level        slog.Level
+		wantErr      bool
+		wantMessage  string
+		wantSeverity string
+	}{
+		{
+			name:      "free reference is silent at the default level",
+			lookupErr: domainErrors.ErrShareNotFound,
+			level:     slog.LevelInfo,
+		},
+		{
+			name:         "free reference is visible at debug",
+			lookupErr:    domainErrors.ErrShareNotFound,
+			level:        slog.LevelDebug,
+			wantMessage:  "share not found by reference",
+			wantSeverity: "DEBUG",
+		},
+		{
+			name:         "an unexpected repository error is still an error",
+			lookupErr:    errors.New("connection refused"),
+			level:        slog.LevelInfo,
+			wantErr:      true,
+			wantMessage:  "failed to get share by reference",
+			wantSeverity: "ERROR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := logtest.Start(tt.level)
+			defer rec.Stop()
+
+			shareRepo := new(sharemockrepo.MockShareRepository)
+			keychainRepo := new(keychainmockrepo.MockKeychainRepository)
+			shareRepo.On("GetByReference", mock.Anything, reference).Return(nil, tt.lookupErr)
+			shareRepo.On("Create", mock.Anything, mock.AnythingOfType("*share.Share")).Return(nil)
+			keychainRepo.On("Get", mock.Anything, keychainID).
+				Return(&keychain.Keychain{ID: keychainID, UserID: userID}, nil)
+
+			// Constructed inside the recorder, since New resolves its destination
+			// when it runs.
+			svc := New(shareRepo, keychainRepo, encryption.NewEncryptionFactory(
+				new(encryptionpartsmockrepo.MockEncryptionPartsRepository),
+				new(projectmockrepo.MockProjectRepository),
+			))
+
+			ref := reference
+			err := svc.Create(context.Background(), &share.Share{
+				UserID:     userID,
+				Secret:     "test-data",
+				KeychainID: &keychainID,
+				Reference:  &ref,
+			})
+
+			if tt.wantErr {
+				require.ErrorIs(t, err, tt.lookupErr, "the returned error must not change")
+			} else {
+				require.NoError(t, err)
+				assert.NotContains(t, rec.Severities(), "ERROR",
+					"registering a share with a free reference must not log an error")
+			}
+
+			if tt.wantMessage == "" {
+				_, found := rec.Find("share not found by reference")
+				assert.False(t, found, "the outcome must be filtered out at this level")
+				return
+			}
+
+			got, found := rec.Find(tt.wantMessage)
+			require.True(t, found, "expected a %q record, got %v", tt.wantMessage, rec.Records())
+			assert.Equal(t, tt.wantSeverity, got.Severity)
+			assert.Equal(t, "share_service", got.Logger)
+
+			if tt.wantSeverity == "ERROR" {
+				assert.Equal(t, tt.lookupErr.Error(), got.Attr("error"),
+					"the error record must still carry the underlying cause")
+			} else {
+				assert.Equal(t, reference, got.Attr("reference"))
+			}
+		})
+	}
+}

--- a/internal/core/services/sharesvc/svc.go
+++ b/internal/core/services/sharesvc/svc.go
@@ -100,8 +100,11 @@ func (s *service) FindByReference(ctx context.Context, reference string) (*share
 	shr, err := s.repo.GetByReference(ctx, reference)
 	if err != nil {
 		if errors.Is(err, domainErrors.ErrShareNotFound) {
-			// Expected outcome, not a failure: callers branch on ErrShareNotFound (see Create).
-			s.logger.WarnContext(ctx, "share not found by reference", slog.String("reference", reference))
+			// Not a failure: Create relies on this to detect a free reference, so a miss is
+			// the success path of a share registration. The InfoContext above already records
+			// the lookup and its reference. Logged at debug, which the default handler level
+			// (nil Level in pkg/logger => LevelInfo) discards.
+			s.logger.DebugContext(ctx, "share not found by reference", slog.String("reference", reference))
 			return nil, err
 		}
 

--- a/internal/core/services/sharesvc/svc.go
+++ b/internal/core/services/sharesvc/svc.go
@@ -99,6 +99,12 @@ func (s *service) FindByReference(ctx context.Context, reference string) (*share
 
 	shr, err := s.repo.GetByReference(ctx, reference)
 	if err != nil {
+		if errors.Is(err, domainErrors.ErrShareNotFound) {
+			// Expected outcome, not a failure: callers branch on ErrShareNotFound (see Create).
+			s.logger.WarnContext(ctx, "share not found by reference", slog.String("reference", reference))
+			return nil, err
+		}
+
 		s.logger.ErrorContext(ctx, "failed to get share by reference", logger.Error(err))
 		return nil, err
 	}

--- a/internal/core/services/sharesvc/svc.go
+++ b/internal/core/services/sharesvc/svc.go
@@ -102,8 +102,8 @@ func (s *service) FindByReference(ctx context.Context, reference string) (*share
 		if errors.Is(err, domainErrors.ErrShareNotFound) {
 			// Not a failure: Create relies on this to detect a free reference, so a miss is
 			// the success path of a share registration. The InfoContext above already records
-			// the lookup and its reference. Logged at debug, which the default handler level
-			// (nil Level in pkg/logger => LevelInfo) discards.
+			// the lookup and its reference, so this is dropped at the default level and only
+			// surfaces under LOG_LEVEL=debug.
 			s.logger.DebugContext(ctx, "share not found by reference", slog.String("reference", reference))
 			return nil, err
 		}

--- a/internal/core/services/usersvc/logging_test.go
+++ b/internal/core/services/usersvc/logging_test.go
@@ -1,0 +1,102 @@
+package usersvc
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/openfort-xyz/shield/internal/adapters/repositories/mocks/usermockedrepo"
+	domainErrors "github.com/openfort-xyz/shield/internal/core/domain/errors"
+	"github.com/openfort-xyz/shield/pkg/logger/logtest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// GetOrCreate looks the external user up and creates one when it is missing, so
+// a miss is the success path of a first-time signup and must not be reported as a
+// failure. It stays available under LOG_LEVEL=debug, and a genuine repository
+// failure keeps its error record.
+func TestGetOrCreateOnFirstSignupLogsNoError(t *testing.T) {
+	const (
+		projectID      = "project"
+		providerID     = "provider"
+		externalUserID = "external"
+	)
+
+	tests := []struct {
+		name         string
+		lookupErr    error
+		level        slog.Level
+		wantErr      bool
+		wantMessage  string
+		wantSeverity string
+	}{
+		{
+			name:      "first signup is silent at the default level",
+			lookupErr: domainErrors.ErrExternalUserNotFound,
+			level:     slog.LevelInfo,
+		},
+		{
+			name:         "first signup is visible at debug",
+			lookupErr:    domainErrors.ErrExternalUserNotFound,
+			level:        slog.LevelDebug,
+			wantMessage:  "external user not found",
+			wantSeverity: "DEBUG",
+		},
+		{
+			name:         "an unexpected repository error is still an error",
+			lookupErr:    errors.New("connection refused"),
+			level:        slog.LevelInfo,
+			wantErr:      true,
+			wantMessage:  "failed to get user by external ID",
+			wantSeverity: "ERROR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rec := logtest.Start(tt.level)
+			defer rec.Stop()
+
+			repo := new(usermockedrepo.MockUserRepository)
+			repo.On("FindUserByExternalID", mock.Anything, externalUserID, providerID).Return(nil, tt.lookupErr)
+			repo.On("Create", mock.Anything, mock.Anything).Return(nil)
+			repo.On("CreateExternal", mock.Anything, mock.Anything).Return(nil)
+
+			// Constructed inside the recorder, since New resolves its destination
+			// when it runs.
+			svc := New(repo)
+
+			_, err := svc.GetOrCreate(context.Background(), projectID, externalUserID, providerID)
+
+			if tt.wantErr {
+				require.ErrorIs(t, err, tt.lookupErr, "the returned error must not change")
+			} else {
+				require.NoError(t, err)
+				assert.NotContains(t, rec.Severities(), "ERROR",
+					"a first-time signup must not log an error")
+			}
+
+			if tt.wantMessage == "" {
+				_, found := rec.Find("external user not found")
+				assert.False(t, found, "the outcome must be filtered out at this level")
+				return
+			}
+
+			got, found := rec.Find(tt.wantMessage)
+			require.True(t, found, "expected a %q record, got %v", tt.wantMessage, rec.Records())
+			assert.Equal(t, tt.wantSeverity, got.Severity)
+			assert.Equal(t, "user_service", got.Logger)
+
+			if tt.wantSeverity == "ERROR" {
+				assert.Equal(t, tt.lookupErr.Error(), got.Attr("error"),
+					"the error record must still carry the underlying cause")
+			} else {
+				assert.Equal(t, externalUserID, got.Attr("external_user_id"))
+				assert.Equal(t, providerID, got.Attr("provider_id"))
+			}
+		})
+	}
+}

--- a/internal/core/services/usersvc/svc.go
+++ b/internal/core/services/usersvc/svc.go
@@ -74,8 +74,11 @@ func (s *service) getByExternal(ctx context.Context, externalUserID, providerID 
 	usr, err := s.repo.FindUserByExternalID(ctx, externalUserID, providerID)
 	if err != nil {
 		if errors.Is(err, domainErrors.ErrExternalUserNotFound) {
-			// Expected outcome, not a failure: GetOrCreate branches on this to create the user.
-			s.logger.WarnContext(ctx, "external user not found", slog.String("external_user_id", externalUserID), slog.String("provider_id", providerID))
+			// Not a failure: GetOrCreate relies on this to create the user, so a miss is the
+			// success path of a first-time signup. The InfoContext above already records the
+			// lookup and its identifiers. Logged at debug, which the default handler level
+			// (nil Level in pkg/logger => LevelInfo) discards.
+			s.logger.DebugContext(ctx, "external user not found", slog.String("external_user_id", externalUserID), slog.String("provider_id", providerID))
 			return nil, err
 		}
 

--- a/internal/core/services/usersvc/svc.go
+++ b/internal/core/services/usersvc/svc.go
@@ -73,6 +73,12 @@ func (s *service) getByExternal(ctx context.Context, externalUserID, providerID 
 
 	usr, err := s.repo.FindUserByExternalID(ctx, externalUserID, providerID)
 	if err != nil {
+		if errors.Is(err, domainErrors.ErrExternalUserNotFound) {
+			// Expected outcome, not a failure: GetOrCreate branches on this to create the user.
+			s.logger.WarnContext(ctx, "external user not found", slog.String("external_user_id", externalUserID), slog.String("provider_id", providerID))
+			return nil, err
+		}
+
 		s.logger.ErrorContext(ctx, "failed to get user by external ID", logger.Error(err))
 		return nil, err
 	}

--- a/internal/core/services/usersvc/svc.go
+++ b/internal/core/services/usersvc/svc.go
@@ -76,8 +76,8 @@ func (s *service) getByExternal(ctx context.Context, externalUserID, providerID 
 		if errors.Is(err, domainErrors.ErrExternalUserNotFound) {
 			// Not a failure: GetOrCreate relies on this to create the user, so a miss is the
 			// success path of a first-time signup. The InfoContext above already records the
-			// lookup and its identifiers. Logged at debug, which the default handler level
-			// (nil Level in pkg/logger => LevelInfo) discards.
+			// lookup and its identifiers, so this is dropped at the default level and only
+			// surfaces under LOG_LEVEL=debug.
 			s.logger.DebugContext(ctx, "external user not found", slog.String("external_user_id", externalUserID), slog.String("provider_id", providerID))
 			return nil, err
 		}

--- a/pkg/logger/handler.go
+++ b/pkg/logger/handler.go
@@ -2,14 +2,34 @@ package logger
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"log/slog"
 	"os"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/openfort-xyz/shield/pkg/contexter"
 )
 
+// LevelEnvVar is the environment variable read by ConfigureFromEnv.
+const LevelEnvVar = "LOG_LEVEL"
+
+var (
+	// levelVar is shared by every handler New builds. Handlers hold a pointer to
+	// it, so changing it also affects loggers that already exist and the level can
+	// be set after the process has loaded its environment. Its zero value is
+	// LevelInfo, which is what slog assumes when HandlerOptions.Level is nil, so
+	// the default behaviour is unchanged.
+	levelVar = new(slog.LevelVar)
+
+	outputMu sync.Mutex
+	output   io.Writer = os.Stdout
+)
+
 var handlerOpts = &slog.HandlerOptions{
+	Level: levelVar,
 	ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
 		switch a.Key {
 		case slog.LevelKey:
@@ -45,9 +65,85 @@ func levelToGCP(level string) string {
 	}
 }
 
+// ParseLevel maps a level name to a slog.Level. It accepts the names slog uses
+// ("debug", "info", "warn", "error") case-insensitively, with an optional numeric
+// offset such as "debug+2", plus "warning" for symmetry with the severity values
+// this package emits.
+func ParseLevel(name string) (slog.Level, error) {
+	trimmed := strings.TrimSpace(name)
+	if strings.EqualFold(trimmed, "warning") {
+		trimmed = "warn"
+	}
+
+	var lvl slog.Level
+	if err := lvl.UnmarshalText([]byte(trimmed)); err != nil {
+		return 0, fmt.Errorf("parsing %s: %w", LevelEnvVar, err)
+	}
+
+	return lvl, nil
+}
+
+// ConfigureFromEnv applies LevelEnvVar to every logger New builds, including the
+// ones it has already built. Call it once the process has loaded its environment,
+// since package initialisation runs before any .env file is read. An unset or
+// empty variable leaves the level at info; an unparseable one is returned as an
+// error and leaves the level untouched.
+func ConfigureFromEnv() error {
+	raw, ok := os.LookupEnv(LevelEnvVar)
+	if !ok || strings.TrimSpace(raw) == "" {
+		return nil
+	}
+
+	lvl, err := ParseLevel(raw)
+	if err != nil {
+		return err
+	}
+
+	levelVar.Set(lvl)
+
+	return nil
+}
+
+// Level reports the minimum level loggers built by New currently emit.
+func Level() slog.Level {
+	return levelVar.Level()
+}
+
+// SetLevel overrides the minimum level for every logger built by New and returns
+// a function restoring the previous level. Intended for tests; production code
+// should go through ConfigureFromEnv.
+func SetLevel(lvl slog.Level) (restore func()) {
+	previous := levelVar.Level()
+	levelVar.Set(lvl)
+
+	return func() { levelVar.Set(previous) }
+}
+
+// SetOutput changes where subsequent calls to New write and returns a function
+// restoring the previous destination. Loggers that already exist keep the
+// destination they were built with, so callers must set the output before
+// constructing whatever they intend to capture. Intended for tests.
+func SetOutput(w io.Writer) (restore func()) {
+	outputMu.Lock()
+	defer outputMu.Unlock()
+
+	previous := output
+	output = w
+
+	return func() {
+		outputMu.Lock()
+		defer outputMu.Unlock()
+		output = previous
+	}
+}
+
 // New creates a new standard logger with a context handler.
 func New(name string) *slog.Logger {
-	return slog.New(NewContextHandler(name, slog.NewJSONHandler(os.Stdout, handlerOpts)))
+	outputMu.Lock()
+	w := output
+	outputMu.Unlock()
+
+	return slog.New(NewContextHandler(name, slog.NewJSONHandler(w, handlerOpts)))
 }
 
 // Error returns an attribute for an error string value.

--- a/pkg/logger/handler_test.go
+++ b/pkg/logger/handler_test.go
@@ -1,0 +1,183 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/openfort-xyz/shield/pkg/contexter"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// capture redirects New to a buffer for the duration of the test and returns it.
+// The logger must be built after this call, since New resolves the destination
+// when it runs.
+func capture(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	buf := &bytes.Buffer{}
+	t.Cleanup(SetOutput(buf))
+
+	return buf
+}
+
+// records decodes every JSON line written to buf.
+func records(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+
+	var out []map[string]any
+
+	decoder := json.NewDecoder(bytes.NewReader(buf.Bytes()))
+	for decoder.More() {
+		var rec map[string]any
+		require.NoError(t, decoder.Decode(&rec))
+		out = append(out, rec)
+	}
+
+	return out
+}
+
+func TestDefaultLevelDropsDebug(t *testing.T) {
+	buf := capture(t)
+	log := New("test")
+
+	log.DebugContext(context.Background(), "dropped")
+	log.InfoContext(context.Background(), "kept")
+
+	recs := records(t, buf)
+	require.Len(t, recs, 1, "debug should not be emitted at the default level")
+	assert.Equal(t, "kept", recs[0]["message"])
+}
+
+func TestSetLevelEnablesDebugOnExistingLoggers(t *testing.T) {
+	buf := capture(t)
+	// Built before the level changes, to prove the handler follows the shared
+	// LevelVar rather than a value captured at construction.
+	log := New("test")
+
+	t.Cleanup(SetLevel(slog.LevelDebug))
+
+	log.DebugContext(context.Background(), "now visible")
+
+	recs := records(t, buf)
+	require.Len(t, recs, 1)
+	assert.Equal(t, "now visible", recs[0]["message"])
+	assert.Equal(t, "DEBUG", recs[0]["severity"])
+}
+
+func TestSetLevelRestores(t *testing.T) {
+	before := Level()
+	restore := SetLevel(slog.LevelError)
+	assert.Equal(t, slog.LevelError, Level())
+	restore()
+	assert.Equal(t, before, Level())
+}
+
+func TestSeverityIsGCPFormatted(t *testing.T) {
+	buf := capture(t)
+	t.Cleanup(SetLevel(slog.LevelDebug))
+	log := New("test")
+
+	ctx := context.Background()
+	log.DebugContext(ctx, "d")
+	log.InfoContext(ctx, "i")
+	log.WarnContext(ctx, "w")
+	log.ErrorContext(ctx, "e")
+
+	recs := records(t, buf)
+	require.Len(t, recs, 4)
+	// WARN is the one that differs: GCP spells it WARNING.
+	assert.Equal(t, []any{"DEBUG", "INFO", "WARNING", "ERROR"},
+		[]any{recs[0]["severity"], recs[1]["severity"], recs[2]["severity"], recs[3]["severity"]})
+}
+
+func TestContextHandlerAddsRequestAndProjectID(t *testing.T) {
+	buf := capture(t)
+	log := New("share_service")
+
+	ctx := contexter.WithProjectID(context.Background(), "project-1")
+	ctx = contexter.WithRequestID(ctx, "request-1")
+	log.InfoContext(ctx, "hello")
+
+	recs := records(t, buf)
+	require.Len(t, recs, 1)
+	assert.Equal(t, "share_service", recs[0]["logger"])
+	assert.Equal(t, "project-1", recs[0][ProjectID])
+	assert.Equal(t, "request-1", recs[0][RequestID])
+}
+
+func TestParseLevel(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    slog.Level
+		wantErr bool
+	}{
+		{name: "lowercase", input: "debug", want: slog.LevelDebug},
+		{name: "uppercase", input: "ERROR", want: slog.LevelError},
+		{name: "mixed case", input: "Warn", want: slog.LevelWarn},
+		{name: "surrounding space", input: "  info  ", want: slog.LevelInfo},
+		{name: "gcp spelling of warn", input: "warning", want: slog.LevelWarn},
+		{name: "offset", input: "debug+2", want: slog.LevelDebug + 2},
+		{name: "unknown name", input: "verbose", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseLevel(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestConfigureFromEnv(t *testing.T) {
+	tests := []struct {
+		name    string
+		set     bool
+		value   string
+		want    slog.Level
+		wantErr bool
+	}{
+		{name: "unset leaves the default", set: false, want: slog.LevelInfo},
+		{name: "empty leaves the default", set: true, value: "", want: slog.LevelInfo},
+		{name: "blank leaves the default", set: true, value: "   ", want: slog.LevelInfo},
+		{name: "debug", set: true, value: "debug", want: slog.LevelDebug},
+		{name: "error", set: true, value: "error", want: slog.LevelError},
+		// An unusable value must not silently change the level, otherwise a typo
+		// could quietly mute the service.
+		{name: "invalid leaves the level untouched", set: true, value: "nope", want: slog.LevelInfo, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(SetLevel(slog.LevelInfo))
+
+			// t.Setenv registers the restore, so unsetting afterwards is still
+			// undone when the subtest finishes.
+			t.Setenv(LevelEnvVar, tt.value)
+			if !tt.set {
+				require.NoError(t, os.Unsetenv(LevelEnvVar))
+			}
+
+			err := ConfigureFromEnv()
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			assert.Equal(t, tt.want, Level())
+		})
+	}
+}

--- a/pkg/logger/logtest/logtest.go
+++ b/pkg/logger/logtest/logtest.go
@@ -2,6 +2,10 @@
 // assert on log level and content. Loggers resolve their destination when they
 // are built, so a recorder has to be started before the code under test is
 // constructed.
+//
+// A recorder redirects the package-global logging configuration, so tests that
+// use one must not call t.Parallel: two recorders alive at once would capture
+// each other's records and restore each other's configuration.
 package logtest
 
 import (
@@ -41,10 +45,20 @@ type Recorder struct {
 // restore the previous destination and level.
 func Start(level slog.Level) *Recorder {
 	rec := &Recorder{}
-	rec.restoreOut = logger.SetOutput(&rec.buf)
+	rec.restoreOut = logger.SetOutput(rec)
 	rec.restoreLvl = logger.SetLevel(level)
 
 	return rec
+}
+
+// Write appends a record to the buffer. The handlers write here, so it takes the
+// same lock as Records and Reset and code under test may log from its own
+// goroutines.
+func (r *Recorder) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.buf.Write(p)
 }
 
 // Stop restores the logging configuration Start replaced. It is safe to call

--- a/pkg/logger/logtest/logtest.go
+++ b/pkg/logger/logtest/logtest.go
@@ -1,0 +1,126 @@
+// Package logtest captures what the application loggers write, so tests can
+// assert on log level and content. Loggers resolve their destination when they
+// are built, so a recorder has to be started before the code under test is
+// constructed.
+package logtest
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"sync"
+
+	"github.com/openfort-xyz/shield/pkg/logger"
+)
+
+// Record is one decoded log line.
+type Record struct {
+	Message  string
+	Severity string
+	Logger   string
+	Attrs    map[string]any
+}
+
+// Attr returns the string value of an attribute, or "" when it is absent or not
+// a string.
+func (r Record) Attr(key string) string {
+	value, _ := r.Attrs[key].(string)
+	return value
+}
+
+// Recorder redirects loggers built by logger.New into a buffer and raises the
+// level so nothing under test is filtered out before it can be asserted on.
+type Recorder struct {
+	mu         sync.Mutex
+	buf        bytes.Buffer
+	restoreOut func()
+	restoreLvl func()
+}
+
+// Start installs a recorder at the given level. Call Stop, normally deferred, to
+// restore the previous destination and level.
+func Start(level slog.Level) *Recorder {
+	rec := &Recorder{}
+	rec.restoreOut = logger.SetOutput(&rec.buf)
+	rec.restoreLvl = logger.SetLevel(level)
+
+	return rec
+}
+
+// Stop restores the logging configuration Start replaced. It is safe to call
+// more than once.
+func (r *Recorder) Stop() {
+	if r.restoreLvl != nil {
+		r.restoreLvl()
+		r.restoreLvl = nil
+	}
+
+	if r.restoreOut != nil {
+		r.restoreOut()
+		r.restoreOut = nil
+	}
+}
+
+// Reset discards everything captured so far, so a table-driven test can reuse
+// one recorder across subtests.
+func (r *Recorder) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.buf.Reset()
+}
+
+// Records decodes everything captured so far. A line that is not valid JSON is
+// skipped, since it did not come from a logger this package installed.
+func (r *Recorder) Records() []Record {
+	r.mu.Lock()
+	raw := r.buf.Bytes()
+	snapshot := make([]byte, len(raw))
+	copy(snapshot, raw)
+	r.mu.Unlock()
+
+	var out []Record
+
+	decoder := json.NewDecoder(bytes.NewReader(snapshot))
+	for decoder.More() {
+		var attrs map[string]any
+		if err := decoder.Decode(&attrs); err != nil {
+			break
+		}
+
+		message, _ := attrs["message"].(string)
+		severity, _ := attrs["severity"].(string)
+		name, _ := attrs["logger"].(string)
+
+		out = append(out, Record{
+			Message:  message,
+			Severity: severity,
+			Logger:   name,
+			Attrs:    attrs,
+		})
+	}
+
+	return out
+}
+
+// Find returns the first record with the given message, and whether one existed.
+func (r *Recorder) Find(message string) (Record, bool) {
+	for _, rec := range r.Records() {
+		if rec.Message == message {
+			return rec, true
+		}
+	}
+
+	return Record{}, false
+}
+
+// Severities returns the severity of every captured record, in order.
+func (r *Recorder) Severities() []string {
+	records := r.Records()
+	out := make([]string, 0, len(records))
+
+	for _, rec := range records {
+		out = append(out, rec.Severity)
+	}
+
+	return out
+}


### PR DESCRIPTION
## Problem

`ErrShareNotFound` and `ErrExternalUserNotFound` are normal control flow, not failures, but four call sites log them at ERROR. In production these two lines are, between them, effectively all of shield's ERROR output — so the ERROR stream carries almost no real failures and any error-rate signal on the service is pinned high by construction.

Why they are not failures:

- `sharesvc.Create` calls `FindByReference` and uses the miss to confirm the reference is free: `if err != nil && !errors.Is(err, domainErrors.ErrShareNotFound)` (`sharesvc/svc.go:49`)
- `usersvc.GetOrCreate` calls `getByExternal` and uses the miss to decide to create the user (`usersvc/svc.go:34`)
- the REST layer maps both to 404s (`api.ErrShareNotFound`, `api.ErrExternalUserNotFound`)

The repository layer already gets this right — it logs the underlying DB failure at ERROR and returns the sentinel bare (`sharerepo/repo.go:91-95`, `userrepo/repo.go:121-124`). The service and application layers then re-logged that sentinel at ERROR. That is the whole source of the problem.

## Change

### 1. The four call sites

Each is split so the sentinel takes a non-error branch and every other error keeps its existing ERROR log.

**Service layer — debug (`sharesvc/svc.go`, `usersvc/svc.go`).** Here the miss is the success path of a larger operation: a share registration with a free reference, or a first-time signup. Both functions already log the lookup and its identifiers via `InfoContext` one line above, so a second record at the same level would only duplicate those attributes.

**Application layer — WARN (`shareapp/app.go`, `GetKeychainShares` and `GetShareByReference`).** Here the miss becomes a 404 on the response rather than a step in a larger operation, and the surrounding app-layer logs carry no attributes of their own, so the record earns its place. `GetKeychainShares` also gained `keychain_id` and a distinct message — both sites previously logged identical text under the same logger name and could not be told apart in a query.

**Returned errors and control flow are unchanged at all four sites.** No caller behaviour, HTTP status, or error value moves. `shareapp` still returns `fromDomainError(err)`, which yields the same `shareapp.ErrShareNotFound` as the fall-through branch; the service sites still return `err` verbatim.

### 2. A configurable level, so debug means something

`handlerOpts` never set `Level`, and slog reads a nil `Level` as `LevelInfo`. Debug records were therefore unreachable by any means, which would have made the level chosen above a permanent drop rather than a level.

`handlerOpts` now carries a shared `slog.LevelVar` and `logger.ConfigureFromEnv` applies `LOG_LEVEL` to it. Handlers hold a pointer to that var, so the setting also reaches loggers built before it is read — which is what lets `main` call it after `godotenv.Load()` and still affect everything. An unset or empty value leaves the level at info, so the default behaviour is unchanged; an unparseable one is reported and ignored rather than silently muting the service. Documented in `.env.example`.

### 3. A seam for asserting on logs

The loggers are built inside each constructor against `os.Stdout`, so nothing could assert on log level or content, and no test in the repo did. `SetOutput` and `SetLevel` return restore functions, and `pkg/logger/logtest` wraps them into a recorder that decodes the JSON records.

New tests:

- `pkg/logger` — level filtering, an existing logger following a later level change, the GCP severity mapping (`WARN` to `WARNING`), the context attributes, level parsing, and every `ConfigureFromEnv` outcome including the invalid one. This package had no tests before.
- `sharesvc` — registering a share with a free reference logs nothing at ERROR, the outcome is recoverable at debug, and a repository failure still logs at ERROR with its cause.
- `usersvc` — the same three cases for a first-time signup.
- `shareapp` — both sites log the miss at WARNING with their identifying attributes, and a repository failure still logs at ERROR. This also gives `GetKeychainShares` its first test coverage.

Every one of these was confirmed to fail against the pre-change code, so they pin the behaviour rather than merely describing it.

## Scope

This covers the two sentinels responsible for the ERROR volume. The same pattern — a bare domain sentinel reaching an `ErrorContext` on a path that ends in a 4xx — exists at roughly a dozen other sites, e.g. `projectsvc.GetByAPIKey` (`projectsvc/svc.go:91`), `shareapp.GetShare` (`app.go:422`), and several `ErrProviderNotFound` / `ErrEncryptionPartNotFound` paths in `projectapp`. None of them currently produce meaningful volume, so they are left for a follow-up rather than folded in here. `identity/factory.go:36-40` already implements the pattern to copy, and `logtest` now makes that follow-up testable.

## Note for anyone with saved queries

The benign case no longer appears under `failed to get share by reference` / `failed to get user by external ID` at ERROR. Dashboards or alerts filtering on those strings will — correctly — match only genuine lookup failures from now on. That is the intent, but worth knowing before it surprises someone.

## Verification

Run locally against Go 1.26.4:

- `gofmt -s -l .` — clean
- `go build ./...` — ok
- `go vet ./...` — ok
- `go test ./...` — all packages pass
- `go test -race ./...` — no data races, which matters because the level and output are now package state
- `golangci-lint run ./...` (v2.11.3, matching CI) — 0 issues
- `LOG_LEVEL=verbose go run ./cmd --help` — warns `Ignoring invalid log level, defaulting to info` and continues; `LOG_LEVEL=debug` is accepted silently

Not verified: the resulting log output in a deployed environment.

Prompted by: Jaume Alavedra